### PR TITLE
automataCI: fixed missing deb library bug

### DIFF
--- a/automataCI/package_unix-any.sh
+++ b/automataCI/package_unix-any.sh
@@ -27,6 +27,7 @@ fi
 . "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/changelog.sh"
 . "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/copyright.sh"
 . "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/manual.sh"
+. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/deb.sh"
 . "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/rpm.sh"
 . "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/flatpak.sh"
 


### PR DESCRIPTION
The deb packaging library was accidentally deleted. Hence, we have to restore it.

This patch fixes missing deb library bug in automataCI/ directory.