### PR TITLE
automataCI: increase coloration intensity

### DIFF
--- a/automataCI/services/io/os.ps1
+++ b/automataCI/services/io/os.ps1
@@ -74,19 +74,19 @@ function OS-Print-Status {
 	switch ($__mode) {
 	"error" {
 		$__msg = "[ ERROR   ] "
-		$__color = "91"
+		$__color = "31"
 	} "warning" {
 		$__msg = "[ WARNING ] "
-		$__color = "93"
+		$__color = "33"
 	} "info" {
 		$__msg = "[ INFO    ] "
-		$__color = "96"
+		$__color = "36"
 	} "success" {
 		$__msg = "[ SUCCESS ] "
-		$__color = "92"
+		$__color = "32"
 	} "ok" {
 		$__msg = "[ INFO    ] == OK == "
-		$__color = "96"
+		$__color = "36"
 	} "plain" {
 		$__msg = $__message
 	} default {

--- a/automataCI/services/io/os.sh
+++ b/automataCI/services/io/os.sh
@@ -36,23 +36,23 @@ OS::print_status() {
         case "$__status_mode" in
         error)
                 __msg="[ ERROR   ] "
-                __color="91"
+                __color="31"
                 ;;
         warning)
                 __msg="[ WARNING ] "
-                __color="93"
+                __color="33"
                 ;;
         info)
                 __msg="[ INFO    ] "
-                __color="96"
+                __color="36"
                 ;;
         success)
                 __msg="[ SUCCESS ] "
-                __color="92"
+                __color="32"
                 ;;
         ok)
                 __msg="[ INFO    ] == OK == "
-                __color="96"
+                __color="36"
                 ;;
         plain)
                 __msg=""


### PR DESCRIPTION
Appearently, the current coloring for print_status is a bit dull. Hence, let's increase it.

This patch increases coloration intensity in automataCI/ directory.