### PR TITLE
srcPYTHON: added stricter requirements for staticx

### DIFF
--- a/srcPYTHON/requirements.txt
+++ b/srcPYTHON/requirements.txt
@@ -6,7 +6,7 @@
 # CI required libraries. Please DO NOT remove. TQ!
 coverage
 pyinstaller
-patchelf-wrapper; sys_platform == 'linux'
-staticx; sys_platform == 'linux'
+patchelf-wrapper; sys_platform == 'linux' and platform_machine == 'x86_64'
+staticx; sys_platform == 'linux' and platform_machine == 'x86_64'
 wheel
 twine


### PR DESCRIPTION
Since staticx specified a strict requirement of only working in 'linux-amd64', it's best to specify the requirement clearly. Hence, let's do this.

This patch adds stricter requirements for staticx in srcPYTHON/ directory.