### PR TITLE
automataCI: added sha256 and sha512 checksum function

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -152,6 +152,22 @@ PROJECT_CONTACT_WEBSITE = "https://your-product.website.here"
 PROJECT_GPG_ID = "49B7878749107ED9C456267ACFD3316C29873FB5"
 
 
+# PROJECT_RELEASE_SHA256
+# Perform SHA256 checksum file generation in Release job. To disable it, simply
+# let it empty.
+#
+# Otherwise, as long as it's not empty, it is enabled.
+PROJECT_RELEASE_SHA256 = "enabled"
+
+
+# PROJECT_RELEASE_SHA512
+# Perform SHA512 checksum file generation. To disable it, simply let it
+# empty.
+#
+# Otherwise, as long as it's not empty, it is enabled.
+PROJECT_RELEASE_SHA512 = "enabled"
+
+
 # PROJECT_DEBIAN_IS_NATIVE
 # Flag to determine the project is Debian natively sponsored package. Usually
 # is false.

--- a/automataCI/services/checksum/shasum.ps1
+++ b/automataCI/services/checksum/shasum.ps1
@@ -1,0 +1,71 @@
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+function SHASUM-Checksum-File {
+	param (
+		[string]$__target,
+		[string]$__algo
+	)
+
+	# validate input
+	if ([string]::IsNullOrEmpty($__target) -or
+		(-not (Test-Path -Path "$__target")) -or
+		[string]::IsNullOrEmpty($__algo)) {
+		return ""
+	}
+
+	# execute
+	switch ($__algo) {
+	'1' {
+		return (Get-FileHash -Path $__target.FullName -Algorithm SHA1).Hash
+	} '224' {
+		return ""
+	} '256' {
+		return (Get-FileHash -Path $__target.FullName -Algorithm SHA256).Hash
+	} '384' {
+		return (Get-FileHash -Path $__target.FullName -Algorithm SHA384).Hash
+	} '512' {
+		return (Get-FileHash -Path $__target.FullName -Algorithm SHA512).Hash
+	} '512224' {
+		return ""
+	} '512256' {
+		return ""
+	} Default {
+		return ""
+	}}
+}
+
+
+
+
+function SHASUM-Is-Available {
+	$__ret = [System.Security.Cryptography.SHA1]::Create("SHA1")
+	if (-not $__ret) {
+		return 1
+	}
+
+	$__ret = [System.Security.Cryptography.SHA256]::Create("SHA256")
+	if (-not $__ret) {
+		return 1
+	}
+
+	$__ret = [System.Security.Cryptography.SHA384]::Create("SHA384")
+	if (-not $__ret) {
+		return 1
+	}
+
+	$__ret = [System.Security.Cryptography.SHA512]::Create("SHA512")
+	if (-not $__ret) {
+		return 1
+	}
+
+	return 0
+}

--- a/automataCI/services/checksum/shasum.sh
+++ b/automataCI/services/checksum/shasum.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at:
+#                http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+SHASUM::create_file() {
+        #__target="$1"
+        #__algo="$2"
+
+        # validate input
+        if [ -z "$1" ] || [ ! -f "$1" ] || [ -z "$2" ]; then
+                return 1
+        fi
+
+        case "$2" in
+        1|224|256|384|512|512224|512256)
+                ;;
+        *)
+                return 1
+                ;;
+        esac
+
+        # execute
+        if [ ! -z "$(type -t shasum)" ]; then
+                __ret="$(shasum -a "$2" "$1")"
+                if [ -z "$__ret" ]; then
+                        return 1
+                fi
+
+                printf "${__ret%% *}"
+                unset __ret
+        fi
+
+        # report status
+        return 0
+}
+
+
+
+
+SHASUM::is_available() {
+        if [ ! -z "$(type -t shasum)" ]; then
+                return 0
+        fi
+
+        return 1
+}


### PR DESCRIPTION
Since SHA256 and SHA512 checksum files are critical for ensuring integrity in the Release job, we should facilitate those functions autonomously. Hence, let's do this.

This patch adds sha256 and sha512 checksum function into automataCI/ directory.