### PR TITLE
automataCI: added notice type to OS::print_status

### DIFF
--- a/automataCI/services/io/os.ps1
+++ b/automataCI/services/io/os.ps1
@@ -81,6 +81,9 @@ function OS-Print-Status {
 	} "info" {
 		$__msg = "[ INFO    ] "
 		$__color = "36"
+	} "note" {
+		$__msg = "[ NOTE    ] "
+		$__color = "35"
 	} "success" {
 		$__msg = "[ SUCCESS ] "
 		$__color = "32"

--- a/automataCI/services/io/os.sh
+++ b/automataCI/services/io/os.sh
@@ -46,6 +46,10 @@ OS::print_status() {
                 __msg="[ INFO    ] "
                 __color="36"
                 ;;
+        note)
+                __msg="[ NOTE    ] "
+                __color="35"
+                ;;
         success)
                 __msg="[ SUCCESS ] "
                 __color="32"

--- a/srcPYTHON/.ci/start_unix-any.sh
+++ b/srcPYTHON/.ci/start_unix-any.sh
@@ -47,9 +47,9 @@ fi
 
 # report what to do since AutomataCI is executable, not sourcable
 OS::print_status info "\n"
-OS::print_status info "IMPORTANT NOTE\n"
-OS::print_status info "please perform the following command at your terminal manually:\n"
-OS::print_status info "    $ . ${VIRTUAL_ENV}/bin/activate\n"
+OS::print_status note "IMPORTANT NOTICE\n"
+OS::print_status note "please perform the following command at your terminal manually:\n"
+OS::print_status note "    $ . ${VIRTUAL_ENV}/bin/activate\n"
 OS::print_status info "\n"
 
 

--- a/srcPYTHON/.ci/start_windows-any.ps1
+++ b/srcPYTHON/.ci/start_windows-any.ps1
@@ -45,9 +45,9 @@ if ($__process -ne 0) {
 
 # report what to do since AutomataCI is executable, not sourcable
 OS-Print-Status info ""
-OS-Print-Status info "IMPORTANT NOTE"
-OS-Print-Status info "please perform the following command at your terminal manually:"
-OS-Print-Status info "    $ ${env:VIRTUAL_ENV}\bin\activate"
+OS-Print-Status note "IMPORTANT NOTE"
+OS-Print-Status note "please perform the following command at your terminal manually:"
+OS-Print-Status note "    $ ${env:VIRTUAL_ENV}\bin\activate"
 OS-Print-Status info ""
 
 


### PR DESCRIPTION
Since the magenta color is left unused, it's better to use it for note then. Hence, let's do this.

This patch adds notice type to OS::print_status in automataCI/ directory.