### PR TITLE
root: added stop recipe for srcPYTHON

### DIFF
--- a/.github/workflows/git-push.yml
+++ b/.github/workflows/git-push.yml
@@ -31,6 +31,10 @@ jobs:
         id: native_ci_purge
         run: |
           ./ci.cmd purge
+      - name: Execute repo's native CI - CLEAN
+        id: native_ci_clean
+        run: |
+          ./ci.cmd clean
       - name: Execute repo's native CI - ENVIRONMENT
         id: native_ci_env
         run: |
@@ -59,6 +63,10 @@ jobs:
         id: native_ci_package
         run: |
           ./ci.cmd package
+      - name: Execute repo's native CI - STOP
+        id: native_ci_stop
+        run: |
+          ./ci.cmd stop
       - name: Archive Build Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/srcPYTHON/.ci/stop_unix-any.sh
+++ b/srcPYTHON/.ci/stop_unix-any.sh
@@ -25,5 +25,16 @@ fi
 
 
 
-OS::print_status success "(placeholder)\n"
+# report what to do since AutomataCI is executable, not sourcable
+OS::print_status info "\n"
+OS::print_status note "IMPORTANT NOTICE\n"
+OS::print_status note "please perform the following command at your terminal manually:\n"
+OS::print_status note "    $ deactivate\n"
+OS::print_status info "\n"
+
+
+
+
+# report status
+OS::print_status success "\n\n"
 return 0

--- a/srcPYTHON/.ci/stop_windows-any.ps1
+++ b/srcPYTHON/.ci/stop_windows-any.ps1
@@ -24,5 +24,16 @@ IF (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 
 
 
-OS-Print-Status success "(placeholder)"
+# report what to do since AutomataCI is executable, not sourcable
+OS-Print-Status info ""
+OS-Print-Status note "IMPORTANT NOTE"
+OS-Print-Status note "please perform the following command at your terminal manually:"
+OS-Print-Status note "    $ deactivate"
+OS-Print-Status info ""
+
+
+
+
+# report status
+OS-Print-Status success ""
 return 0


### PR DESCRIPTION
Since the stop recipe was left out, we should develop its executions now. Hence, let's do this.

This patch adds stop recipe for srcPYTHON in root directory.