### PR TITLE
automataCI: added changelog entries seal function for Release job

### DIFF
--- a/automataCI/_release-functions_unix-any.sh
+++ b/automataCI/_release-functions_unix-any.sh
@@ -14,6 +14,7 @@
 . "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
 . "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/versioners/git.sh"
 . "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/crypto/gpg.sh"
+. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/changelog.sh"
 . "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/checksum/shasum.sh"
 
 
@@ -133,6 +134,7 @@ ${__value}  ${TARGET##*/}
 
 
 
+
 RELEASE::initiate() {
         # safety check control surfaces
         OS::print_status info "Checking shasum availability...\n"
@@ -159,6 +161,23 @@ RELEASE::initiate() {
                 if [ $? -ne 0 ]; then
                         return 1
                 fi
+        fi
+
+        # report status
+        return 0
+}
+
+
+
+
+RELEASE::run_changelog_conclude() {
+        # execute
+        OS::print_status info "Sealing changelog latest entries...\n"
+        CHANGELOG::seal \
+                "${PROJECT_PATH_ROOT}/${PROJECT_PATH_RESOURCES}/changelog" \
+                "$PROJECT_VERSION"
+        if [ $? -ne 0 ]; then
+                return 1
         fi
 
         # report status

--- a/automataCI/_release-functions_windows-any.ps1
+++ b/automataCI/_release-functions_windows-any.ps1
@@ -13,6 +13,7 @@
 . "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
 . "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\versioners\git.ps1"
 . "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\crypto\gpg.ps1"
+. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\compilers\changelog.ps1"
 . "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\checksum\shasum.ps1"
 
 
@@ -163,7 +164,24 @@ function RELEASE-Initiate {
 
 
 
-function Release-Run-Release-Repo-Conclude {
+function RELEASE-Run-Changelog-Conclude {
+	# execute
+	OS-Print-Status info "Sealing changelog latest entries..."
+	$__process = CHANGELOG-Seal `
+		"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\changelog" `
+		"${env:PROJECT_VERSION}"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	# report status
+	return 0
+}
+
+
+
+
+function RELEASE-Run-Release-Repo-Conclude {
 	# validate input
 	$__process = GIT-Is-Available
 	if ($__process -ne 0) {

--- a/automataCI/release_unix-any.sh
+++ b/automataCI/release_unix-any.sh
@@ -109,6 +109,12 @@ if [ $? -ne 0 ]; then
 fi
 
 
+RELEASE::run_changelog_conclude
+if [ $? -ne 0 ]; then
+        return 1
+fi
+
+
 
 
 # report status

--- a/automataCI/release_windows-any.ps1
+++ b/automataCI/release_windows-any.ps1
@@ -108,6 +108,12 @@ if ($__process -ne 0) {
 }
 
 
+$__process = RELEASE-Run-Changelog-Conclude
+if ($__process -ne 0) {
+	return 1
+}
+
+
 
 
 # report status

--- a/automataCI/services/compilers/changelog.ps1
+++ b/automataCI/services/compilers/changelog.ps1
@@ -15,18 +15,168 @@
 
 
 
-function CHANGELOG-Is-Available {
-	$__program = Get-Command git -ErrorAction SilentlyContinue
-	if (-not ($__program)) {
+function CHANGELOG-Assemble-DEB {
+	param (
+		[string]$__directory,
+		[string]$__target,
+		[string]$__version
+	)
+
+	if ([string]::IsNullOrEmpty($__directory) -or
+		[string]::IsNullOrEmpty($__target) -or
+		[string]::IsNullOrEmpty($__version)) {
 		return 1
 	}
 
-	$__process = GZ-Is-Available
+	$__directory = "${__directory}\deb"
+	$__target = $__target -replace '\.gz.*$'
+
+	# assemble file
+	$null = FS-Remove-Silently "${__target}"
+	$null = FS-Remove-Silently "${__target}.gz"
+	$null = FS-Make-Housing-Directory "${__target}"
+
+	foreach ($__line in (Get-Content "${__directory}\latest")) {
+		$__process = FS-Append-File "${__target}" "${__line}"
+		if ($__process -ne 0) {
+			return 1
+		}
+	}
+
+	foreach ($__tag in (git tag --sort version:refname)) {
+		if (-not (Test-Path "${__directory}\${__tag}")) {
+			continue
+		}
+
+		foreach ($__line in (Get-Content "${__directory}\${__tag}")) {
+			$__process = FS-Append-File "${__target}" "`n${__line}"
+			if ($__process -ne 0) {
+				return 1
+			}
+		}
+	}
+
+	# gunzip
+	$__process = GZ-Create "${__target}"
+
+	# report status
+	return $__process
+}
+
+
+
+
+function CHANGELOG-Assemble-MD {
+	param (
+		[string]$__directory,
+		[string]$__target,
+		[string]$__version,
+		[string]$__title
+	)
+
+	if ([string]::IsNullOrEmpty($__directory) -or
+		[string]::IsNullOrEmpty($__target) -or
+		[string]::IsNullOrEmpty($__version) -or
+		[string]::IsNullOrEmpty($__title)) {
+		return 1
+	}
+
+	$__directory = "${__directory}\data"
+
+	# assemble file
+	$null = FS-Remove-Silently "${__target}"
+	$null = FS-Make-Housing-Directory "${__target}"
+	$null = FS-Write-File "${__target}" "# ${__title}`n"
+	$null = FS-Append-File "${__target}" "`n## ${__version}`n"
+	foreach ($__line in (Get-Content "${__directory}\latest")) {
+		$__process = FS-Append-File "${__target}" "* ${__line}"
+		if ($__process -ne 0) {
+			return 1
+		}
+	}
+
+	foreach ($__tag in (git tag --sort version:refname)) {
+		if (-not (Test-Path "${__directory}\${__tag}")) {
+			continue
+		}
+
+		$null = FS-Append-File "${__target}" "`n`n##${__tag}`n"
+		foreach ($__line in (Get-Content "${__directory}\${__tag}")) {
+			$__process = FS-Append-File "${__target}" "* ${__line}"
+			if ($__process -ne 0) {
+				return 1
+			}
+		}
+	}
+
+	# report status
+	return $__process
+}
+
+
+
+
+function CHANGELOG-Assemble-RPM {
+	param (
+		[string]$__target,
+		[string]$__resources,
+		[string]$__date,
+		[string]$__name,
+		[string]$__email,
+		[string]$__version,
+		[string]$__cadence
+	)
+
+	# validate input
+	if ([string]::IsNullOrEmpty($__target) -or
+		[string]::IsNullOrEmpty($__resources) -or
+		[string]::IsNullOrEmpty($__date) -or
+		[string]::IsNullOrEmpty($__name) -or
+		[string]::IsNullOrEmpty($__email) -or
+		[string]::IsNullOrEmpty($__version) -or
+		[string]::IsNullOrEmpty($__cadence) -or
+		(-not (Test-Path -Path "${__target}")) -or
+		(-not (Test-Path -Path "${__resources}" -PathType Container))) {
+		return 1
+	}
+
+	# emit stanza
+	$__process = FS-Write-File "${__target}" "%%changelog`n"
 	if ($__process -ne 0) {
 		return 1
 	}
 
-	return 0
+	# emit latest changelog
+	if (Test-Path -Path "${__resources}\changelog\data\latest") {
+		$__process = FS-Append-File "${__target}" `
+			"* ${__date} ${__name} <${__email}> - ${__version}-${__cadence}`n"
+		if ($__process -ne 0) {
+			return 1
+		}
+
+		Get-Content -Path "${__directory}\changelog\data\latest" | ForEach-Object {
+			$__line = $_ -replace '#.*'
+			if ([string]::IsNullOrEmpty($__line)) {
+				continue
+			}
+
+			$__process = FS-Append-File "${__target}" "  * ${__line}"
+			if ($__process -ne 0) {
+				return 1
+			}
+		}
+	} else {
+		$__process = FS-Append-File "${__target}" "# unavailable`n"
+		if ($__process -ne 0) {
+			return 1
+		}
+	}
+
+	# emit tailing newline
+	$__process = FS-Append-File "${__target}" "`n"
+
+	# report status
+	return $__process
 }
 
 
@@ -179,166 +329,55 @@ function CHANGELOG-Compatible-DEB-Version {
 
 
 
-function CHANGELOG-Assemble-DEB {
-	param (
-		[string]$__directory,
-		[string]$__target,
-		[string]$__version
-	)
-
-	if ([string]::IsNullOrEmpty($__directory) -or
-		[string]::IsNullOrEmpty($__target) -or
-		[string]::IsNullOrEmpty($__version)) {
+function CHANGELOG-Is-Available {
+	$__program = Get-Command git -ErrorAction SilentlyContinue
+	if (-not ($__program)) {
 		return 1
 	}
 
-	$__directory = "${__directory}\deb"
-	$__target = $__target -replace '\.gz.*$'
-
-	# assemble file
-	$null = FS-Remove-Silently "${__target}"
-	$null = FS-Remove-Silently "${__target}.gz"
-	$null = FS-Make-Housing-Directory "${__target}"
-
-	foreach ($__line in (Get-Content "${__directory}\latest")) {
-		$__process = FS-Append-File "${__target}" "${__line}"
-		if ($__process -ne 0) {
-			return 1
-		}
-	}
-
-	foreach ($__tag in (git tag --sort version:refname)) {
-		if (-not (Test-Path "${__directory}\${__tag}")) {
-			continue
-		}
-
-		foreach ($__line in (Get-Content "${__directory}\${__tag}")) {
-			$__process = FS-Append-File "${__target}" "`n${__line}"
-			if ($__process -ne 0) {
-				return 1
-			}
-		}
-	}
-
-	# gunzip
-	$__process = GZ-Create "${__target}"
-
-	# report status
-	return $__process
-}
-
-
-
-
-function CHANGELOG-Assemble-RPM {
-	param (
-		[string]$__target,
-		[string]$__resources,
-		[string]$__date,
-		[string]$__name,
-		[string]$__email,
-		[string]$__version,
-		[string]$__cadence
-	)
-
-	# validate input
-	if ([string]::IsNullOrEmpty($__target) -or
-		[string]::IsNullOrEmpty($__resources) -or
-		[string]::IsNullOrEmpty($__date) -or
-		[string]::IsNullOrEmpty($__name) -or
-		[string]::IsNullOrEmpty($__email) -or
-		[string]::IsNullOrEmpty($__version) -or
-		[string]::IsNullOrEmpty($__cadence) -or
-		(-not (Test-Path -Path "${__target}")) -or
-		(-not (Test-Path -Path "${__resources}" -PathType Container))) {
-		return 1
-	}
-
-	# emit stanza
-	$__process = FS-Write-File "${__target}" "%%changelog`n"
+	$__process = GZ-Is-Available
 	if ($__process -ne 0) {
 		return 1
 	}
 
-	# emit latest changelog
-	if (Test-Path -Path "${__resources}\changelog\data\latest") {
-		$__process = FS-Append-File "${__target}" `
-			"* ${__date} ${__name} <${__email}> - ${__version}-${__cadence}`n"
-		if ($__process -ne 0) {
-			return 1
-		}
-
-		Get-Content -Path "${__directory}\changelog\data\latest" | ForEach-Object {
-			$__line = $_ -replace '#.*'
-			if ([string]::IsNullOrEmpty($__line)) {
-				continue
-			}
-
-			$__process = FS-Append-File "${__target}" "  * ${__line}"
-			if ($__process -ne 0) {
-				return 1
-			}
-		}
-	} else {
-		$__process = FS-Append-File "${__target}" "# unavailable`n"
-		if ($__process -ne 0) {
-			return 1
-		}
-	}
-
-	# emit tailing newline
-	$__process = FS-Append-File "${__target}" "`n"
-
-	# report status
-	return $__process
+	return 0
 }
 
 
 
 
-function CHANGELOG-Assemble-MD {
+function CHANGELOG-Seal {
 	param (
 		[string]$__directory,
-		[string]$__target,
-		[string]$__version,
-		[string]$__title
+		[string]$__version
 	)
 
+	# validate input
 	if ([string]::IsNullOrEmpty($__directory) -or
-		[string]::IsNullOrEmpty($__target) -or
 		[string]::IsNullOrEmpty($__version) -or
-		[string]::IsNullOrEmpty($__title)) {
+		(-not (Test-Path -Path "${__directory}" -PathType Container))) {
 		return 1
 	}
 
-	$__directory = "${__directory}\data"
-
-	# assemble file
-	$null = FS-Remove-Silently "${__target}"
-	$null = FS-Make-Housing-Directory "${__target}"
-	$null = FS-Write-File "${__target}" "# ${__title}`n"
-	$null = FS-Append-File "${__target}" "`n## ${__version}`n"
-	foreach ($__line in (Get-Content "${__directory}\latest")) {
-		$__process = FS-Append-File "${__target}" "* ${__line}"
-		if ($__process -ne 0) {
-			return 1
-		}
+	if (-not (Test-Path -Path "${__directory}\data\latest")) {
+		return 1
 	}
 
-	foreach ($__tag in (git tag --sort version:refname)) {
-		if (-not (Test-Path "${__directory}\${__tag}")) {
-			continue
-		}
+	if (-not (Test-Path -Path "${__directory}\deb\latest")) {
+		return 1
+	}
 
-		$null = FS-Append-File "${__target}" "`n`n##${__tag}`n"
-		foreach ($__line in (Get-Content "${__directory}\${__tag}")) {
-			$__process = FS-Append-File "${__target}" "* ${__line}"
-			if ($__process -ne 0) {
-				return 1
-			}
-		}
+	# execute
+	$__process = FS-Move "${__directory}\data\latest" "${__directory}\data\${__version}"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	$__process = FS-Move "${__directory}\deb\latest" "${__directory}\deb\${__version}"
+	if ($__process -ne 0) {
+		return 1
 	}
 
 	# report status
-	return $__process
+	return 0
 }


### PR DESCRIPTION
Since there is a need to seal the changelog entries during the Release job execution, it's best we facilitate one. Hence, let's do this.

This patch adds changelog entries seal function for Release job in automataCI/ directory.