### PR TITLE
automataCI: added static repo compulsory notice file

### DIFF
--- a/automataCI/_release-functions_unix-any.sh
+++ b/automataCI/_release-functions_unix-any.sh
@@ -199,6 +199,17 @@ RELEASE::run_release_repo_conclude() {
         # execute
         __current_path="$PWD" && cd "${PROJECT_PATH_ROOT}/${PROJECT_PATH_RELEASE}"
 
+
+        OS::print_status info "Generate required notice file...\n"
+        FS::write_file "Home.md" "\
+# ${PROJECT_NAME} Static Distribution Repository
+
+This is a re-purposed repository for housing various distribution ecosystem
+such as but not limited to \`.deb\`, \`.rpm\`, \`.flatpak\`, and etc for folks
+to \`apt-get install\`, \`yum install\`, or \`flatpak install\`.
+"
+
+
         OS::print_status info "Committing release repo...\n"
         GIT::autonomous_force_commit \
                 "$__tag" \

--- a/automataCI/_release-functions_windows-any.ps1
+++ b/automataCI/_release-functions_windows-any.ps1
@@ -200,6 +200,15 @@ function RELEASE-Run-Release-Repo-Conclude {
 	$__current_path = Get-Location
 	$null = Set-Location "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RELEASE}"
 
+	OS-Print-Status info "Generate required notice file..."
+	$null = FS-Write-File "Home.md" @"
+# ${env:PROJECT_NAME} Static Distribution Repository
+
+This is a re-purposed repository for housing various distribution ecosystem
+such as but not limited to ``.deb``, ``.rpm``, ``.flatpak``, and etc for folks
+to ``apt-get install``, ``yum install``, or ``flatpak install``.
+"@
+
 	OS-Print-Status info "Committing release repo..."
 	$__process = Git-Autonomous-Force-Commit `
 		"${__tag}" `


### PR DESCRIPTION
Since static repo is utilizing a git repository, it's best we add a compulsory notice file generation. Hence, let's do this.

This patch adds static repo compulsory notice file in automataCI/ directory.