### PR TITLE
automataCI: added printout consistency for all jobs

### DIFF
--- a/automataCI/env_unix-any.sh
+++ b/automataCI/env_unix-any.sh
@@ -83,4 +83,5 @@ fi
 
 
 # report status
+OS::print_status success "\n\n"
 return 0

--- a/automataCI/env_windows-any.ps1
+++ b/automataCI/env_windows-any.ps1
@@ -82,4 +82,5 @@ if (-not [string]::IsNullOrEmpty(${env:PROJECT_PYTHON})) {
 
 
 # report status
+OS-Print-Status success "`n"
 return 0

--- a/automataCI/purge_unix-any.sh
+++ b/automataCI/purge_unix-any.sh
@@ -54,5 +54,6 @@ FS::remove_silently "$__target"
 
 
 
-# return status
+# report status
+OS::print_status success "\n\n"
 return 0

--- a/automataCI/purge_windows-any.ps1
+++ b/automataCI/purge_windows-any.ps1
@@ -58,5 +58,6 @@ FS-Remove-Silently "${__target}"
 
 
 
-# return status
+# report status
+OS-Print-Status success "`n"
 return 0


### PR DESCRIPTION
Since there are some jobs (notably 'env' and 'purge') having inconsistent printout, we should proceed to fix them. Hence, let's do this.

This patch adds printout consistency for all jobs in automataCI/ directory.