### PR TITLE
README.md: corrected typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ in the `automataCI/AutomataCI-Engineering-Specification.pdf` documentation.
 
 ### Update GitHub Integration Configurations
 
-Why usually not required, you can update the GitHub integration files inside
+While usually not required, you can update the GitHub integration files inside
 `.github` directory. Notable files are:
 
 1. `.github/ISSUE_TEMPLATES/*` - issue templates.


### PR DESCRIPTION
There was a typo in the README.md file. Hence, let's correct it.

This patch corrects some typo in the README.md.