### PR TITLE
srcGO: added wasm support

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -97,7 +97,7 @@ PROJECT_SOURCE_URL = "https://github.com/ChewKeanHo/AutomataCI"
 #
 # To enable it: simply supply the path (e.g. default is 'srcGO').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_GO = ''
+PROJECT_GO = 'srcGO'
 
 
 # PROJECT_PATH_GO_ENGINE
@@ -119,7 +119,7 @@ PROJECT_PATH_GO_ENGINE = "go-engine"
 #
 # To enable it: simply supply the path (e.g. default is 'srcC').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_C = 'srcC'
+PROJECT_C = ''
 
 
 

--- a/resources/changelog/data/latest
+++ b/resources/changelog/data/latest
@@ -1,2 +1,3 @@
+root: enabled Emscripten WASM compilation for C
 root: added C Programming Language support
 README.md: corrected typo

--- a/resources/changelog/deb/latest
+++ b/resources/changelog/deb/latest
@@ -1,6 +1,7 @@
 automataci (1.6.0) stable; urgency=low
 
+  * root: enabled Emscripten WASM compilation for C
   * root: added C Programming Language support
   * README.md: corrected typo
 
--- Your Legal Full Name Here <contact@youremail.example>  Tue, 03 Oct 2023 09:57:23 +0800
+-- Your Legal Full Name Here <contact@youremail.example>  Tue, 03 Oct 2023 12:30:50 +0800

--- a/src/.ci/_package-archive_windows-any.ps1
+++ b/src/.ci/_package-archive_windows-any.ps1
@@ -38,7 +38,7 @@ function PACKAGE-Assemble-Archive-Content {
 	# copy main program
 	if ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
 		return 10 # not applicable
-	} elseif ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
+	} elseif ($(FS-Is-Target-A-Library "${__target}") -eq 0) {
 		OS-Print-Status info "copying ${__target} to ${__directory}"
 		$__process = Fs-Copy-File "${__target}" "${__directory}"
 		if ($__process -ne 0) {

--- a/srcC/.ci/_package-archive_unix-any.sh
+++ b/srcC/.ci/_package-archive_unix-any.sh
@@ -35,7 +35,6 @@ PACKAGE::assemble_archive_content() {
 
 
         # package based on target's nature
-        FS::is_target_a_source "$__target"
         if [ $(FS::is_target_a_source "$__target") -eq 0 ]; then
                 __target="${PROJECT_PATH_ROOT}/${PROJECT_C}/libs"
                 OS::print_status info "copying ${__target} to ${__directory}\n"

--- a/srcGO/.ci/_package-docker_unix-any.sh
+++ b/srcGO/.ci/_package-docker_unix-any.sh
@@ -33,13 +33,20 @@ PACKAGE::assemble_docker_content() {
         __target_os="$4"
         __target_arch="$5"
 
+
         # validate project
-        FS::is_target_a_source "$__target"
-        if [ $? -eq 0 ]; then
-                return 10
+        if [ $(FS::is_target_a_source "$__target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_library "$__target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_wasm_js "$__target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_wasm "$__target") -eq 0 ]; then
+                return 10 # not applicable
         fi
 
         OS::print_status info "Running Go specific content assembling function...\n"
+
 
         # assemble the package
         FS::copy_file "$__target" "${__directory}/${PROJECT_SKU}"
@@ -51,6 +58,7 @@ PACKAGE::assemble_docker_content() {
         if [ $? -ne 0 ]; then
                 return 1
         fi
+
 
         # generate the Dockerfile
         FS::write_file "${__directory}/Dockerfile" "\
@@ -95,6 +103,7 @@ ENTRYPOINT [\"/app/bin/${PROJECT_SKU}\"]
         if [ $? -ne 0 ]; then
                 return 1
         fi
+
 
         # report status
         return 0

--- a/srcGO/.ci/_package-docker_windows-any.ps1
+++ b/srcGO/.ci/_package-docker_windows-any.ps1
@@ -34,13 +34,20 @@ function PACKAGE-Assemble-DOCKER-Content {
 		[string]$__target_arch
 	)
 
+
 	# validate project
-	$__process = FS-Is-Target-A-Source "${__target}"
-	if ($__process -ne 0) {
-		return 10
+	if ($(FS-Is-Target-A-Source "${__target}") -ne 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-Library "${__target}") -ne 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-WASM-JS "${__target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-WASM "${__target}") -eq 0) {
+		return 10 # not applicable
 	}
 
 	OS-Print-Status info "Running Go specific content assembling function..."
+
 
 	# assemble the package
 	$__process = FS-Copy-File "${__target}" "${__directory}\${env:PROJECT_SKU}"
@@ -52,6 +59,7 @@ function PACKAGE-Assemble-DOCKER-Content {
 	if ($__process -ne 0) {
 		return 1
 	}
+
 
 	# generate the Dockerfile
 	$__process = FS-Write-File "${__directory}\Dockerfile" @"
@@ -96,6 +104,7 @@ ENTRYPOINT ["/app/bin/${env:PROJECT_SKU}"]
 	if ($__process -ne 0) {
 		return 1
 	}
+
 
 	# report status
 	return 0

--- a/srcGO/.ci/build_windows-any.ps1
+++ b/srcGO/.ci/build_windows-any.ps1
@@ -54,52 +54,83 @@ $__go_arch = ${env:GOARCH}
 ${env:CGO_ENABLED} = 0
 :loop foreach ($__platform in (Invoke-Expression "go tool dist list")) {
 	# select supported platforms
+	$__os = $__platform.Split("/")[0]
+	$__arch = $__platform.Split("/")[1]
 	$__arguments = ""
+
 	switch ($__platform) {
 	"aix/ppc64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "android/amd64" {
 		continue loop
 	} "android/arm64" {
 		continue loop
 	} "darwin/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 		$__arguments = "-buildmode=pie "
 	} "darwin/arm64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 		$__arguments = "-buildmode=pie "
 	} "dragonfly/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "freebsd/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "illumos/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "ios/amd64" {
 		continue loop
 	} "ios/arm64" {
 		continue loop
+	} "js/wasm" {
+		$__filename = "${__output_directory}\${env:PROJECT_SKU}_${__os}-${__arch}.js"
+		$null = FS-Remove-Silently "${__filename}"
+		$__process = FS-Copy-File `
+			"$(Invoke-Expression "go env GOROOT")/misc/wasm/wasm_exec.js" `
+			"${__filename}"
+		if ($__process -ne 0) {
+			return 1
+		}
+
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}.wasm"
 	} "linux/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 		$__arguments = "-buildmode=pie "
 	} "linux/arm64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 		$__arguments = "-buildmode=pie "
 	} "linux/ppc64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "linux/ppc64le" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 		$__arguments = "-buildmode=pie "
 	} "linux/riscv64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "linux/s390x" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "netbsd/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "netbsd/arm64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "openbsd/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "openbsd/arm64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "plan9/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "solaris/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 	} "windows/amd64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}.exe"
 		$__arguments = "-buildmode=pie "
 	} "windows/arm64" {
+		$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}.exe"
 		$__arguments = "-buildmode=pie "
 	} Default {
 		continue loop
 	}}
 
-	# building target
-	$__os = $__platform.Split("/")[0]
-	$__arch = $__platform.Split("/")[1]
-	$__filename = "${env:PROJECT_SKU}_${__os}-${__arch}"
 
+	# building target
 	OS-Print-Status info "building ${__filename}..."
 	$null = FS-Remove-Silently "${__output_directory}\${__filename}"
 	${env:GOOS} = $__os


### PR DESCRIPTION
Since we enabled wasm support for C Programming Language and Go Programming Language has its own built-in version, we should enable it so that Go developers can enjoy using WASM as well. Hence, let's do this.

This patch adds wasm support in srcGO/ directory.