### PR TITLE
srcPYTHON: backported all latest CI changes

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -97,7 +97,7 @@ PROJECT_SOURCE_URL = "https://github.com/ChewKeanHo/AutomataCI"
 #
 # To enable it: simply supply the path (e.g. default is 'srcGO').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_GO = 'srcGO'
+PROJECT_GO = ''
 
 
 # PROJECT_PATH_GO_ENGINE
@@ -136,7 +136,7 @@ PROJECT_C = ''
 #
 # To enable it: simply supply the path (e.g. default is 'srcPYTHON').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_PYTHON = ''
+PROJECT_PYTHON = 'srcPYTHON'
 
 
 # PROJECT_PATH_PYTHON_ENGINE

--- a/resources/changelog/data/latest
+++ b/resources/changelog/data/latest
@@ -1,3 +1,4 @@
+srcGO: added wasm support
 root: enabled Emscripten WASM compilation for C
 root: added C Programming Language support
 README.md: corrected typo

--- a/resources/changelog/deb/latest
+++ b/resources/changelog/deb/latest
@@ -1,7 +1,8 @@
 automataci (1.6.0) stable; urgency=low
 
+  * srcGO: added wasm support
   * root: enabled Emscripten WASM compilation for C
   * root: added C Programming Language support
   * README.md: corrected typo
 
--- Your Legal Full Name Here <contact@youremail.example>  Tue, 03 Oct 2023 12:30:50 +0800
+-- Your Legal Full Name Here <contact@youremail.example>  Tue, 03 Oct 2023 13:29:33 +0800

--- a/srcPYTHON/.ci/_package-archive_windows-any.ps1
+++ b/srcPYTHON/.ci/_package-archive_windows-any.ps1
@@ -35,10 +35,9 @@ function PACKAGE-Assemble-Archive-Content {
 		[string]$__target_arch
 	)
 
+
 	# copy main program
-	$__process = FS-Is-Target-A-Source "${__target}"
-	if ($__process -eq 0) {
-		# it's a source code target
+	if ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
 		$__target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\Libs"
 		PYTHON-Clean-Artifact "${__target}"
 		OS-Print-Status info "copying ${__target} to ${__directory}"
@@ -47,8 +46,29 @@ function PACKAGE-Assemble-Archive-Content {
 			OS-Print-Status error "copy failed."
 			return 1
 		}
+	} elseif ($(FS-Is-Target-A-Library "${__target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-WASM-JS "${__target}") -eq 0) {
+		return 10 # handled by wasm instead
+	} elseif ($(FS-Is-Target-A-WASM "${__target}") -eq 0) {
+		OS-Print-Status info "copying ${__target} to ${__directory}"
+		$__process = Fs-Copy-File "${__target}" "${__directory}"
+		if ($__process -ne 0) {
+			return 1
+		}
+
+		$__process = FS-Is-File "$($__target -replace '\.wasm.*$', '.js')"
+		if ($__process -eq 0) {
+			OS-Print-Status info `
+				"copying $($__target -replace '\.wasm.*$', '.js') to ${__directory}"
+			$__process = Fs-Copy-File `
+					"$($__target -replace '\.wasm.*$', '.js')" `
+					"${__directory}"
+			if ($__process -ne 0) {
+				return 1
+			}
+		}
 	} else {
-		# it's a binary target
 		switch (${__target_os}) {
 		"windows" {
 			$__dest = "${__directory}\${env:PROJECT_SKU}.exe"
@@ -64,6 +84,7 @@ function PACKAGE-Assemble-Archive-Content {
 		}
 	}
 
+
 	# copy user guide
 	$__target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\docs\USER-GUIDES-EN.pdf"
 	OS-Print-Status info "copying ${__target} to ${__directory}"
@@ -73,6 +94,7 @@ function PACKAGE-Assemble-Archive-Content {
 		return 1
 	}
 
+
 	# copy license file
 	$__target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\licenses\LICENSE-EN.pdf"
 	OS-Print-Status info "copying ${__target} to ${__directory}"
@@ -81,6 +103,7 @@ function PACKAGE-Assemble-Archive-Content {
 		OS-Print-Status error "copy failed."
 		return 1
 	}
+
 
 	# report status
 	return 0

--- a/srcPYTHON/.ci/_package-docker_unix-any.sh
+++ b/srcPYTHON/.ci/_package-docker_unix-any.sh
@@ -33,10 +33,16 @@ PACKAGE::assemble_docker_content() {
         __target_os="$4"
         __target_arch="$5"
 
+
         # validate project
-        FS::is_target_a_source "$__target"
-        if [ $? -eq 0 ]; then
-                return 10
+        if [ $(FS::is_target_a_source "$__target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_library "$__target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_wasm_js "$__target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_wasm "$__target") -eq 0 ]; then
+                return 10 # not applicable
         fi
 
         case "$__target_os" in
@@ -46,7 +52,9 @@ PACKAGE::assemble_docker_content() {
                 return 10
                 ;;
         esac
+
         OS::print_status info "running python specific content assembling function...\n"
+
 
         # assemble the package
         FS::copy_file "$__target" "${__directory}/${PROJECT_SKU}"
@@ -58,6 +66,7 @@ PACKAGE::assemble_docker_content() {
         if [ $? -ne 0 ]; then
                 return 1
         fi
+
 
         # generate the Dockerfile
         FS::write_file "${__directory}/Dockerfile" "\
@@ -113,6 +122,7 @@ ENTRYPOINT [\"/app/bin/${PROJECT_SKU}\"]
         if [ $? -ne 0 ]; then
                 return 1
         fi
+
 
         # report status
         return 0

--- a/srcPYTHON/.ci/_package-docker_windows-any.ps1
+++ b/srcPYTHON/.ci/_package-docker_windows-any.ps1
@@ -34,19 +34,27 @@ function PACKAGE-Assemble-DOCKER-Content {
 		[string]$__target_arch
 	)
 
+
 	# validate project
-	$__process = FS-Is-Target-A-Source "${__target}"
-	if ($__process -ne 0) {
-		return 10
+	if ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-Library "${__target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-WASM-JS "${__target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-WASM "${__target}") -eq 0) {
+		return 10 # not applicable
 	}
 
 	switch ($__target_os) {
 	{ $_ -in 'linux', 'windows' } {
 		# accepted
-	} Default {
+	} default {
 		return 10
 	}}
+
 	OS-Print-Status info "running python specific content assembling function..."
+
 
 	# assemble the package
 	$__process = FS-Copy-File "${__target}" "${__directory}\${env:PROJECT_SKU}"
@@ -58,6 +66,7 @@ function PACKAGE-Assemble-DOCKER-Content {
 	if ($__process -ne 0) {
 		return 1
 	}
+
 
 	# generate the Dockerfile
 	$__process = FS-Write-File "${__directory}\Dockerfile" @"
@@ -113,6 +122,7 @@ ENTRYPOINT ["/app/bin/${PROJECT_SKU}"]
 	if ($__process -ne 0) {
 		return 1
 	}
+
 
 	# report status
 	return 0

--- a/srcPYTHON/.ci/_package-pypi_unix-any.sh
+++ b/srcPYTHON/.ci/_package-pypi_unix-any.sh
@@ -33,6 +33,7 @@ PACKAGE::assemble_pypi_content() {
         __target_os="$4"
         __target_arch="$5"
 
+
         # validate project
         FS::is_target_a_source "$__target"
         if [ $? -ne 0 ]; then
@@ -42,6 +43,7 @@ PACKAGE::assemble_pypi_content() {
         if [ -z "$PROJECT_PYTHON" ]; then
                 return 10
         fi
+
 
         # assemble the python package
         PYTHON::clean_artifact "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/"
@@ -56,6 +58,7 @@ PACKAGE::assemble_pypi_content() {
         if [ $? -ne 0 ]; then
                 return 1
         fi
+
 
         # generate the pyproject.toml
         FS::write_file "${__directory}/pyproject.toml" "\
@@ -89,6 +92,7 @@ Homepage = '${PROJECT_CONTACT_WEBSITE}'
         if [ $? -ne 0 ]; then
                 return 1
         fi
+
 
         # report status
         return 0

--- a/srcPYTHON/.ci/_package-pypi_windows-any.ps1
+++ b/srcPYTHON/.ci/_package-pypi_windows-any.ps1
@@ -34,6 +34,7 @@ function PACKAGE-Assemble-PYPI-Content {
 		[string]$__target_arch
 	)
 
+
 	# validate project
 	$__process = FS-Is-Target-A-Source "$__target"
 	if ($__process -ne 0) {
@@ -43,6 +44,7 @@ function PACKAGE-Assemble-PYPI-Content {
 	if ([string]::IsNullOrEmpty($env:PROJECT_PYTHON)) {
 		return 10
 	}
+
 
 	# assemble the python package
 	PYTHON-Clean-Artifact "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}"
@@ -57,6 +59,7 @@ function PACKAGE-Assemble-PYPI-Content {
 	if ($__process -ne 0) {
 		return 1
 	}
+
 
 	# generate the pyproject.toml
 	$__process = FS-Write-File "${__directory}\pyproject.toml" @"
@@ -90,6 +93,7 @@ Homepage = '${env:PROJECT_CONTACT_WEBSITE}'
 	if ($__process -ne 0) {
 		return 1
 	}
+
 
 	# report status
 	return 0


### PR DESCRIPTION
Since Python Programming Language is hardened and left out after enabling C and Go, it's time to backport all the latest CI changes into it. Hence, let's do this.

This patch backports all latest CI changes into srcPYTHON/ directory.