### PR TITLE
automataCI: added yum's source.repo data file generative function

### DIFF
--- a/automataCI/services/compilers/deb.ps1
+++ b/automataCI/services/compilers/deb.ps1
@@ -344,6 +344,8 @@ function DEB-Create-Source-List {
 
 
 	# execute
+	$__url = "${__url}/deb"
+	$__url = $__url -replace "//deb", "/deb"
 	$__key = "usr\local\share\keyrings\${__sku}-keyring.gpg"
 	$__filename = "${__directory}\data\etc\apt\sources.list.d\${__sku}.list"
 

--- a/automataCI/services/compilers/deb.sh
+++ b/automataCI/services/compilers/deb.sh
@@ -339,6 +339,8 @@ DEB::create_source_list() {
 
 
         # execute
+        __url="${__url}/deb"
+        __url="${__url%//deb*}/deb"
         __key="usr/local/share/keyrings/${__sku}-keyring.gpg"
         __filename="${__directory}/data/etc/apt/sources.list.d/${__sku}.list"
 

--- a/automataCI/services/compilers/rpm.ps1
+++ b/automataCI/services/compilers/rpm.ps1
@@ -16,35 +16,63 @@
 
 
 
-function RPM-Is-Available {
-	param(
-		[string]$__os,
+function RPM-Create-Archive {
+	param (
+		[string]$__directory,
+		[string]$__destination,
+		[string]$__sku,
 		[string]$__arch
 	)
 
-	# validate dependencies
-	$__process = OS-Is-Command-Available "rpmbuild"
-	if ($__process -ne 0) {
+
+	# validate input
+	if ([string]::IsNullOrEmpty($__directory) -or
+		[string]::IsNullOrEmpty($__destination) -or
+		[string]::IsNullOrEmpty($__sku) -or
+		(-not (Test-Path $__directory -PathType Container)) -or
+		(-not (Test-Path $__destination -PathType Container)) -or
+		(-not (Test-Path "${__directory}\SPECS\${__sku}.spec" -PathType Container))) {
 		return 1
 	}
 
-	# check compatible target os
-	switch ($__os) {
-	windows {
-		return 2
-	} darwin {
-		return 2
-	} Default {
-		Break
-	}}
 
-	# check compatible target cpu architecture
-	switch ($__arch) {
-	any {
-		return 3
-	} Default {
-		Break
-	}}
+	# change directory into workspace
+	$__current_path = Get-Location
+	Set-Location -Path $__directory
+
+
+	# archive into rpm
+	$null = FS-Make-Directory ".\BUILD"
+	$null = FS-Make-Directory ".\BUILDROOT"
+	$null = FS-Make-Directory ".\RPMS"
+	$null = FS-Make-Directory ".\SOURCES"
+	$null = FS-Make-Directory ".\SPECS"
+	$null = FS-Make-Directory ".\SRPMCS"
+	$null = FS-Make-Directory ".\tmp"
+	$__arguments = "--define `"_topdir ${__directory}`" " +
+			"--define `"debug_package %{nil}`" " +
+			"--define `"__strip /bin/true`" " +
+			"--target `"$__arch`" " +
+			"-ba `"${__directory}\SPECS\${__sku}.spec`""
+	$__process = OS-Exec "rpmbuild" "$__arguments"
+	if ($__process -ne 0) {
+		Set-Location -Path $__current_path
+		Remove-Variable -Name __current_path
+		return 1
+	}
+
+
+	# return back to current path
+	Set-Location -Path $__current_path
+	Remove-Variable -Name __current_path
+
+
+	# move to destination
+	foreach($__package in (Get-ChildItem -Path "${__directory}/RPMS/${__arch}")) {
+		$null = FS-Remove-Silently "${__destination}\${__package}.Name"
+		$null = FS-Move "$_.FullName" "${__destination}"
+	}
+
 
 	# report status
 	return 0
@@ -53,25 +81,101 @@ function RPM-Is-Available {
 
 
 
-function REB-Is-Valid {
-	param (
-		[string]$__target
+function RPM-Create-Source-Repo {
+	param(
+		[string]$__is_simulated,
+		[string]$__directory,
+		[string]$__gpg_id,
+		[string]$__url,
+		[string]$__name,
+		[string]$__sku
 	)
 
-	# validate input
-	if ([string]::IsNullOrEmpty($__target) -or
-		(Test-Path "${__target}" -PathType Container) -or
-		(-not (Test-Path "${__target}"))) {
-		return 1
-	}
 
-	# execute
-	if ($(${__target} -split '\.')[-1] -eq "rpm") {
+	# validate input
+	if (-not [string]::IsNullOrEmpty($__is_simulated)) {
 		return 0
 	}
 
+	if ([string]::IsNullOrEmpty(${__directory}) -or
+		(-not (Test-Path "${__directory}" -PathType Container)) -or
+		[string]::IsNullOrEmpty(${__gpg_id}) -or
+		[string]::IsNullOrEmpty(${__url}) -or
+		[string]::IsNullOrEmpty(${__name}) -or
+		[string]::IsNullOrEmpty(${__sku})) {
+		return 1
+	}
+
+	$__process = FS-Is-File "${__directory}\SPEC_INSTALL"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	$__process = FS-Is-File "${__directory}\SPEC_FILES"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+
+	# execute
+	$__url = "${__url}/rpm"
+	$__url = $__url -replace "//rpm", "/rpm"
+	$__key = "usr\local\share\keyrings\${__sku}-keyring.gpg"
+	$__filename = "etc\yum.repos.d\${__sku}.list"
+
+	$__process = FS-Is-File "$(Split-Path -Leaf -Path "${__filename}")"
+	if ($__process -eq 0) {
+		return 10
+	}
+
+	$__process = FS-Is-File "$(Split-Path -Leaf -Path "${__key}")"
+	if ($__process -eq 0) {
+		return 1
+	}
+
+	$null = FS-Make-Directory "${__directory}\BUILD"
+	$__process = FS-Write-File `
+		"${__directory}\BUILD\$(Split-Path -Leaf -Path "${__filename}")" @"
+# WARNING: AUTO-GENERATED - DO NOT EDIT!
+[${__sku}]
+name=${__name}
+baseurl=${__url}
+gpgcheck=1
+gpgkey=file:///${__key}
+"@
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	$__process = GPG-Export-Public-Keyring `
+		"${__directory}\BUILD\$(Split-Path -Leaf -Path "${__key}")" `
+		"${__gpg_id}"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	$__process = FS-Append-File "${__directory}\SPEC_INSTALL" @"
+install --directory %{buildroot}/$(Split-Path -Parent -Path "${__filename}")
+install -m 0644 $(Split-Path -Leaf -Path "${__filename}") %{buildroot}/$(Split-Path -Parent -Path "${__filename}")
+
+install --directory %{buildroot}/$(Split-Path -Parent -Path "${__key}")
+install -m 0644 $(Split-Path -Leaf -Path "${__key}") %{buildroot}/$(Split-Path -Parent -Path "${__key}")
+"@
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	$__process = FS-Append-File "${__directory}\SPEC_FILES" @"
+/${__filename}
+/${__key}
+"@
+	if ($__process -ne 0) {
+		return 1
+	}
+
+
 	# report status
-	return 1
+	return 0
 }
 
 
@@ -91,6 +195,7 @@ function RPM-Create-Spec {
 		[string]$__license
 	)
 
+
 	# validate input
 	if ([string]::IsNullOrEmpty($__directory) -or
 		(-not (Test-Path $__directory -PathType Container)) -or
@@ -107,14 +212,17 @@ function RPM-Create-Spec {
 		return 1
 	}
 
+
 	# check if is the document already injected
 	$__location = "${__directory}\SPECS\${__sku}.spec"
 	if (Test-Path $__location) {
 		return 2
 	}
 
+
 	# create housing directory path
 	$null = FS-Make-Housing-Directory $__location
+
 
 	# generate spec file's header
 	$null = FS-Write-File $__location @"
@@ -126,6 +234,7 @@ Release: ${__cadence}
 License: ${__license}
 URL: ${__website}
 "@
+
 
 	# generate spec file's description field
 	$null = FS-Append-File $__location "%%description`n"
@@ -154,6 +263,7 @@ URL: ${__website}
 	}
 	$null = FS-Append-File $__location "`n"
 
+
 	# generate spec file's prep field
 	$null = FS-Append-File $__location "%%prep`n"
 	if (Test-Path "${__directory}\SPEC_PREPARE") {
@@ -171,6 +281,7 @@ URL: ${__website}
 		$null = FS-Append-File $__location "`n"
 	}
 	$null = FS-Append-File $__location "`n"
+
 
 	# generate spec file's build field
 	$null = FS-Append-File $__location "%%build`n"
@@ -190,6 +301,7 @@ URL: ${__website}
 	}
 	$null = FS-Append-File $__location "`n"
 
+
 	# generate spec file's install field
 	$null = FS-Append-File $__location "%%install`n"
 	if (Test-Path "${__directory}\SPEC_INSTALL") {
@@ -207,6 +319,7 @@ URL: ${__website}
 		$null = FS-Append-File $__location "`n"
 	}
 	$null = FS-Append-File $__location "`n"
+
 
 	# generate spec file's clean field
 	$null = FS-Append-File $__location "%%clean`n"
@@ -226,6 +339,7 @@ URL: ${__website}
 	}
 	$null = FS-Append-File $__location "`n"
 
+
 	# generate spec file's files field
 	$null = FS-Append-File $__location "%%files`n"
 	if (Test-Path "${__directory}\SPEC_FILES") {
@@ -243,6 +357,7 @@ URL: ${__website}
 		$null = FS-Append-File $__location "`n"
 	}
 	$null = FS-Append-File $__location "`n"
+
 
 	# generate spec file's changelog field
 	if (Test-Path "${__directory}\SPEC_CHANGELOG") {
@@ -273,6 +388,7 @@ URL: ${__website}
 		}
 	}
 
+
 	# report status
 	return 0
 }
@@ -280,58 +396,67 @@ URL: ${__website}
 
 
 
-function RPM-Create-Archive {
-	param (
-		[string]$__directory,
-		[string]$__destination,
-		[string]$__sku,
+function RPM-Is-Available {
+	param(
+		[string]$__os,
 		[string]$__arch
 	)
 
-	# validate input
-	if ([string]::IsNullOrEmpty($__directory) -or
-		[string]::IsNullOrEmpty($__destination) -or
-		[string]::IsNullOrEmpty($__sku) -or
-		(-not (Test-Path $__directory -PathType Container)) -or
-		(-not (Test-Path $__destination -PathType Container)) -or
-		(-not (Test-Path "${__directory}\SPECS\${__sku}.spec" -PathType Container))) {
-		return 1
-	}
 
-	# change directory into workspace
-	$__current_path = Get-Location
-	Set-Location -Path $__directory
-
-	# archive into rpm
-	$null = FS-Make-Directory ".\BUILD"
-	$null = FS-Make-Directory ".\BUILDROOT"
-	$null = FS-Make-Directory ".\RPMS"
-	$null = FS-Make-Directory ".\SOURCES"
-	$null = FS-Make-Directory ".\SPECS"
-	$null = FS-Make-Directory ".\SRPMCS"
-	$null = FS-Make-Directory ".\tmp"
-	$__arguments = "--define `"_topdir ${__directory}`" " +
-			"--define `"debug_package %{nil}`" " +
-			"--define `"__strip /bin/true`" " +
-			"--target `"$__arch`" " +
-			"-ba `"${__directory}\SPECS\${__sku}.spec`""
-	$__process = OS-Exec "rpmbuild" "$__arguments"
+	# validate dependencies
+	$__process = OS-Is-Command-Available "rpmbuild"
 	if ($__process -ne 0) {
-		Set-Location -Path $__current_path
-		Remove-Variable -Name __current_path
 		return 1
 	}
 
-	# return back to current path
-	Set-Location -Path $__current_path
-	Remove-Variable -Name __current_path
 
-	# move to destination
-	foreach($__package in (Get-ChildItem -Path "${__directory}/RPMS/${__arch}")) {
-		$null = FS-Remove-Silently "${__destination}\${__package}.Name"
-		$null = FS-Move "$_.FullName" "${__destination}"
-	}
+	# check compatible target os
+	switch ($__os) {
+	windows {
+		return 2
+	} darwin {
+		return 2
+	} Default {
+		Break
+	}}
+
+
+	# check compatible target cpu architecture
+	switch ($__arch) {
+	any {
+		return 3
+	} Default {
+		Break
+	}}
+
 
 	# report status
 	return 0
+}
+
+
+
+
+function REB-Is-Valid {
+	param (
+		[string]$__target
+	)
+
+
+	# validate input
+	if ([string]::IsNullOrEmpty($__target) -or
+		(Test-Path "${__target}" -PathType Container) -or
+		(-not (Test-Path "${__target}"))) {
+		return 1
+	}
+
+
+	# execute
+	if ($(${__target} -split '\.')[-1] -eq "rpm") {
+		return 0
+	}
+
+
+	# report status
+	return 1
 }

--- a/automataCI/services/compilers/rpm.sh
+++ b/automataCI/services/compilers/rpm.sh
@@ -17,36 +17,58 @@
 
 
 
-RPM::is_available() {
-        __os="$1"
-        __arch="$2"
+RPM::create_archive() {
+        __directory="$1"
+        __destination="$2"
+        __sku="$3"
+        __arch="$4"
 
-        if [ -z "$__os" ] || [ -z "$__arch" ]; then
+
+        # validate input
+        if [ -z "$__directory" ] ||
+                [ -z "$__destination" ] ||
+                [ -z "$__sku" ] ||
+                [ ! -d "$__directory" ] ||
+                [ ! -d "$__destination" ] ||
+                [ ! -f "${__directory}/SPECS/${__sku}.spec" ]; then
                 return 1
         fi
 
-        # validate dependencies
-        if [ -z "$(type -t 'rpmbuild')" ]; then
+
+        # change directory into workspace
+        __current_path="$PWD" && cd "${__directory}"
+
+
+        # archive into rpm
+        FS::make_directory "./BUILD"
+        FS::make_directory "./BUILDROOT"
+        FS::make_directory "./RPMS"
+        FS::make_directory "./SOURCES"
+        FS::make_directory "./SPECS"
+        FS::make_directory "./SRPMCS"
+        FS::make_directory "./tmp"
+        rpmbuild \
+                --define "_topdir ${__directory}" \
+                --define "debug_package %{nil}" \
+                --define "__strip /bin/true" \
+                --target "$__arch" \
+                -ba "${__directory}/SPECS/${__sku}.spec"
+        if [ $? -ne 0 ]; then
+                cd "$__current_path" && unset __current_path
                 return 1
         fi
 
-        # check compatible target os
-        case "$__os" in
-        windows|darwin)
-                return 2
-                ;;
-        *)
-                ;;
-        esac
 
-        # check compatible target cpu architecture
-        case "$__arch" in
-        any)
-                return 3
-                ;;
-        *)
-                ;;
-        esac
+        # return back to current path
+        cd "$__current_path" && unset __current_path
+
+
+        # move to destination
+        for package in "${__directory}/RPMS/${__arch}/"*; do
+                FS::remove_silently "${__destination}/${package##*/}"
+                FS::move "$package" "$__destination"
+        done
+
 
         # report status
         return 0
@@ -55,21 +77,96 @@ RPM::is_available() {
 
 
 
-RPM::is_valid() {
-        #__target="$1"
+RPM::create_source_repo() {
+        __is_simulated="$1"
+        __directory="$2"
+        __gpg_id="$3"
+        __url="$4"
+        __name="$5"
+        __sku="$6"
+
 
         # validate input
-        if [ -z "$1" ] || [ -d "$1" ] || [ ! -f "$1" ]; then
-                return 1
-        fi
-
-        # execute
-        if [ "${1##*.}" = "rpm" ]; then
+        if [ ! -z "$__is_simulated" ]; then
                 return 0
         fi
 
-        # return status
-        return 1
+        if [ -z "$__directory" ] ||
+                [ ! -d "$__directory" ] ||
+                [ -z "$__gpg_id" ] ||
+                [ -z "$__url" ] ||
+                [ -z "$__name" ] ||
+                [ -z "$__sku" ]; then
+                return 1
+        fi
+
+        FS::is_file "${__directory}/SPEC_INSTALL"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        FS::is_file "${__directory}/SPEC_FILES"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+
+        # execute
+        __url="${__url}/rpm"
+        __url="${__url%//rpm*}/rpm"
+        __key="usr/local/share/keyrings/${__sku}-keyring.gpg"
+        __filename="etc/yum.repos.d/${__sku}.repo"
+
+        FS::is_file "${__directory}/BUILD/${__filename##*/}"
+        if [ $? -eq 0 ]; then
+                return 10
+        fi
+
+        FS::is_file "${__directory}/BUILD/${__key##*/}"
+        if [ $? -eq 0 ]; then
+                return 1
+        fi
+
+        FS::make_directory "${__directory}/BUILD"
+        FS::write_file "${__directory}/BUILD/${__filename##*/}" "\
+# WARNING: AUTO-GENERATED - DO NOT EDIT!
+[${__sku}]
+name=${__name}
+baseurl=${__url}
+gpgcheck=1
+gpgkey=file:///${__key}
+"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        GPG::export_public_keyring "${__directory}/BUILD/${__key##*/}" "$__gpg_id"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        FS::append_file "${__directory}/SPEC_INSTALL" "
+install --directory %{buildroot}/${__filename%/*}
+install -m 0644 ${__filename##*/} %{buildroot}/${__filename%/*}
+
+install --directory %{buildroot}/${__key%/*}
+install -m 0644 ${__key##*/} %{buildroot}/${__key%/*}
+"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        FS::append_file "${__directory}/SPEC_FILES" "\
+/${__filename}
+/${__key}
+"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+
+        # report status
+        return 0
 }
 
 
@@ -87,6 +184,7 @@ RPM::create_spec() {
         __website="$9"
         __license="${10}"
 
+
         # validate input
         if [ -z "$__directory" ] ||
                 [ ! -d "$__directory" ] ||
@@ -103,14 +201,17 @@ RPM::create_spec() {
                 return 1
         fi
 
+
         # check if is the document already injected
         __location="${__directory}/SPECS/${__sku}.spec"
         if [ -f "$__location" ]; then
                 return 2
         fi
 
+
         # create housing directory path
         FS::make_housing_directory "$__location"
+
 
         # generate spec file's header
         FS::write_file "$__location" "\
@@ -122,6 +223,7 @@ License: ${__license}
 URL: ${__website}
 
 "
+
 
         # generate spec file's description field
         FS::append_file "$__location" "%%description\n"
@@ -154,6 +256,7 @@ URL: ${__website}
         fi
         FS::append_file "$__location" "\n"
 
+
         # generate spec file's prep field
         FS::append_file "$__location" "%%prep\n"
         if [ -f "${__directory}/SPEC_PREPARE" ]; then
@@ -173,6 +276,7 @@ URL: ${__website}
                 FS::append_file "$__location" "\n"
         fi
         FS::append_file "$__location" "\n"
+
 
         # generate spec file's build field
         FS::append_file "$__location" "%%build\n"
@@ -194,6 +298,7 @@ URL: ${__website}
         fi
         FS::append_file "$__location" "\n"
 
+
         # generate spec file's install field
         FS::append_file "$__location" "%%install\n"
         if [ -f "${__directory}/SPEC_INSTALL" ]; then
@@ -213,6 +318,7 @@ URL: ${__website}
                 FS::append_file "$__location" "\n"
         fi
         FS::append_file "$__location" "\n"
+
 
         # generate spec file's clean field
         FS::append_file "$__location" "%%clean\n"
@@ -234,6 +340,7 @@ URL: ${__website}
         fi
         FS::append_file "$__location" "\n"
 
+
         # generate spec file's files field
         FS::append_file "$__location" "%%files\n"
         if [ -f "${__directory}/SPEC_FILES" ]; then
@@ -253,6 +360,7 @@ URL: ${__website}
                 FS::append_file "$__location" "\n"
         fi
         FS::append_file "$__location" "\n"
+
 
         # generate spec file's changelog field
         if [ -f "${__directory}/SPEC_CHANGELOG" ]; then
@@ -285,6 +393,7 @@ URL: ${__website}
                 fi
         fi
 
+
         # report status
         return 0
 }
@@ -292,53 +401,64 @@ URL: ${__website}
 
 
 
-RPM::create_archive() {
-        __directory="$1"
-        __destination="$2"
-        __sku="$3"
-        __arch="$4"
+RPM::is_available() {
+        __os="$1"
+        __arch="$2"
 
-        # validate input
-        if [ -z "$__directory" ] ||
-                [ -z "$__destination" ] ||
-                [ -z "$__sku" ] ||
-                [ ! -d "$__directory" ] ||
-                [ ! -d "$__destination" ] ||
-                [ ! -f "${__directory}/SPECS/${__sku}.spec" ]; then
+        if [ -z "$__os" ] || [ -z "$__arch" ]; then
                 return 1
         fi
 
-        # change directory into workspace
-        __current_path="$PWD" && cd "${__directory}"
 
-        # archive into rpm
-        FS::make_directory "./BUILD"
-        FS::make_directory "./BUILDROOT"
-        FS::make_directory "./RPMS"
-        FS::make_directory "./SOURCES"
-        FS::make_directory "./SPECS"
-        FS::make_directory "./SRPMCS"
-        FS::make_directory "./tmp"
-        rpmbuild \
-                --define "_topdir ${__directory}" \
-                --define "debug_package %{nil}" \
-                --define "__strip /bin/true" \
-                --target "$__arch" \
-                -ba "${__directory}/SPECS/${__sku}.spec"
-        if [ $? -ne 0 ]; then
-                cd "$__current_path" && unset __current_path
+        # validate dependencies
+        if [ -z "$(type -t 'rpmbuild')" ]; then
                 return 1
         fi
 
-        # return back to current path
-        cd "$__current_path" && unset __current_path
 
-        # move to destination
-        for package in "${__directory}/RPMS/${__arch}/"*; do
-                FS::remove_silently "${__destination}/${package##*/}"
-                FS::move "$package" "$__destination"
-        done
+        # check compatible target os
+        case "$__os" in
+        windows|darwin)
+                return 2
+                ;;
+        *)
+                ;;
+        esac
+
+
+        # check compatible target cpu architecture
+        case "$__arch" in
+        any)
+                return 3
+                ;;
+        *)
+                ;;
+        esac
+
 
         # report status
         return 0
+}
+
+
+
+
+RPM::is_valid() {
+        #__target="$1"
+
+
+        # validate input
+        if [ -z "$1" ] || [ -d "$1" ] || [ ! -f "$1" ]; then
+                return 1
+        fi
+
+
+        # execute
+        if [ "${1##*.}" = "rpm" ]; then
+                return 0
+        fi
+
+
+        # return status
+        return 1
 }

--- a/src/.ci/_package-deb_unix-any.sh
+++ b/src/.ci/_package-deb_unix-any.sh
@@ -36,6 +36,7 @@ PACKAGE::assemble_deb_content() {
 
 
         # validate target before job
+        __keyring="$PROJECT_SKU"
         if [ $(FS::is_target_a_source "$__target") -eq 0 ]; then
                 return 10 # not applicable
         elif [ $(FS::is_target_a_library "$__target") -eq 0 ]; then
@@ -86,29 +87,26 @@ PACKAGE::assemble_deb_content() {
                 fi
         fi
 
-        OS::print_status info "overriding source.list file...\n"
-        __url="${PROJECT_STATIC_URL}/deb"
-        if [ -z "$__keyring" ]; then
-                __keyring="$PROJECT_SKU"
-        fi
-        DEB::create_source_list \
-                "$PROJECT_SIMULATE_RELEASE_REPO" \
-                "$__directory" \
-                "$PROJECT_GPG_ID" \
-                "${__url%//deb*}/deb" \
-                "$PROJECT_REPREPRO_CODENAME" \
-                "$PROJECT_DEBIAN_DISTRIBUTION" \
-                "$__keyring"
-        if [ $? -ne 0 ]; then
-                return 1
-        fi
-
 
         # OPTIONAL (overrides): copy usr/share/docs/${PROJECT_SKU}/changelog.gz
         # OPTIONAL (overrides): copy usr/share/docs/${PROJECT_SKU}/copyright.gz
         # OPTIONAL (overrides): copy usr/share/man/man1/${PROJECT_SKU}.1.gz
         # OPTIONAL (overrides): generate ${__directory}/control/md5sum
         # OPTIONAL (overrides): generate ${__directory}/control/control
+
+
+        OS::print_status info "creating source.list files...\n"
+        DEB::create_source_list \
+                "$PROJECT_SIMULATE_RELEASE_REPO" \
+                "$__directory" \
+                "$PROJECT_GPG_ID" \
+                "$PROJECT_STATIC_URL" \
+                "$PROJECT_REPREPRO_CODENAME" \
+                "$PROJECT_DEBIAN_DISTRIBUTION" \
+                "$__keyring"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
 
 
         # report status

--- a/src/.ci/_package-deb_windows-any.ps1
+++ b/src/.ci/_package-deb_windows-any.ps1
@@ -37,6 +37,7 @@ function PACKAGE-Assemble-DEB-Content {
 
 
 	# validate target before job
+	$__keyring = "${env:PROJECT_SKU}"
 	if ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
 		return 10 # not applicable
 	} elseif ($(FS-Is-Target-A-Library "${__target}") -eq 0) {
@@ -85,32 +86,27 @@ function PACKAGE-Assemble-DEB-Content {
 		}
 	}
 
-	OS-Print-Status info "overriding source.list file..."
-	if ([string]::IsNullOrEmpty($__keyring)) {
-		$__keyring = "${env:PROJECT_SKU}"
-	}
-
-	$__url = "${env:PROJECT_STATIC_URL}/deb"
-	$__url = $__url -replace "//deb", "/deb"
-	$__process = DEB-Create-Source-List `
-		"${env:PROJECT_DEBIAN_CREATE_SOURCE_LIST}" `
-		"${env:PROJECT_SIMULATE_RELEASE_REPO}" `
-		"${__directory}" `
-		"${env:PROJECT_GPG_ID}" `
-		"${__url}" `
-		"${env:PROJECT_REPREPRO_CODENAME}" `
-		"${env:PROJECT_DEBIAN_DISTRIBUTION}" `
-		"${__keyring}"
-	if ($__process -ne 0) {
-		return 1
-	}
-
 
 	# OPTIONAL (overrides): copy usr/share/docs/${env:PROJECT_SKU}/changelog.gz
 	# OPTIONAL (overrides): copy usr/share/docs/${env:PROJECT_SKU}/copyright.gz
 	# OPTIONAL (overrides): copy usr/share/man/man1/${env:PROJECT_SKU}.1.gz
 	# OPTIONAL (overrides): generate ${__directory}/control/md5sum
 	# OPTIONAL (overrides): generate ${__directory}/control/control
+
+
+	OS-Print-Status info "creating source.list files..."
+	$__process = DEB-Create-Source-List `
+		"${env:PROJECT_DEBIAN_CREATE_SOURCE_LIST}" `
+		"${env:PROJECT_SIMULATE_RELEASE_REPO}" `
+		"${__directory}" `
+		"${env:PROJECT_GPG_ID}" `
+		"${env:PROJECT_STATIC_URL}" `
+		"${env:PROJECT_REPREPRO_CODENAME}" `
+		"${env:PROJECT_DEBIAN_DISTRIBUTION}" `
+		"${__keyring}"
+	if ($__process -ne 0) {
+		return 1
+	}
 
 
 	# report status

--- a/src/.ci/_package-rpm_unix-any.sh
+++ b/src/.ci/_package-rpm_unix-any.sh
@@ -35,7 +35,7 @@ PACKAGE::assemble_rpm_content() {
 
 
         # validate target before job
-        FS::is_target_a_source "$__target"
+        __keyring="$PROJECT_SKU"
         if [ $(FS::is_target_a_source "$__target") -eq 0 ]; then
                 return 10 # not applicable
         elif [ $(FS::is_target_a_library "$__target") -eq 0 ]; then
@@ -76,6 +76,8 @@ install -m 0644 copyright %{buildroot}/usr/local/share/doc/lib${PROJECT_SKU}/
                 if [ $? -ne 0 ]; then
                         return 1
                 fi
+
+                __keyring="lib$PROJECT_SKU"
         elif [ $(FS::is_target_a_wasm_js "$__target") -eq 0 ]; then
                 return 10 # not applicable
         elif [ $(FS::is_target_a_wasm "$__target") -eq 0 ]; then
@@ -127,6 +129,19 @@ install -m 0644 ${PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
         # OPTIONAL (overrides): ${__directory}/BUILD/copyright.gz
         # OPTIONAL (overrides): ${__directory}/BUILD/man.1.gz
         # OPTIONAL (overrides): ${__directory}/SPECS/${PROJECT_SKU}.spec
+
+
+        OS::print_status info "creating source.repo files...\n"
+        RPM::create_source_repo \
+                "$PROJECT_SIMULATE_RELEASE_REPO" \
+                "$__directory" \
+                "$PROJECT_GPG_ID" \
+                "$PROJECT_STATIC_URL" \
+                "$PROJECT_NAME" \
+                "$__keyring"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
 
 
         # report status

--- a/src/.ci/_package-rpm_windows-any.ps1
+++ b/src/.ci/_package-rpm_windows-any.ps1
@@ -36,6 +36,7 @@ function PACKAGE-Assemble-RPM-Content {
 
 
 	# validate target before job
+	$__keyring = "${env:PROJECT_SKU}"
 	if ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
 		return 10 # not applicable
 	} elseif ($(FS-Is-Target-A-Library "${__target}") -eq 0) {
@@ -76,6 +77,8 @@ install -m 0644 copyright %{buildroot}/usr/local/share/doc/lib${env:PROJECT_SKU}
 		if ($__process -ne 0) {
 			return 1
 		}
+
+		$__keyring = "lib${env:PROJECT_SKU}"
 	} elseif ($(FS-Is-Target-A-WASM-JS "${__target}") -eq 0) {
 		return 10 # not applicable
 	} elseif ($(FS-Is-Target-A-WASM "${__target}") -eq 0) {
@@ -135,6 +138,20 @@ install -m 644 ${env:PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
 	# OPTIONAL (overrides): ${__directory}/BUILD/copyright.gz
 	# OPTIONAL (overrides): ${__directory}/BUILD/man.1.gz
 	# OPTIONAL (overrides): ${__directory}/SPECS/${env:PROJECT_SKU}.spec
+
+
+	OS-Print-Status info "creating source.repo files..."
+	$__process = RPM-Create-Source-Repo `
+		"${env:PROJECT_SIMULATE_RELEASE_REPO}" `
+		"${__directory}" `
+		"${env:PROJECT_GPG_ID}" `
+		"${env:PROJECT_STATIC_URL}" `
+		"${env:PROJECT_REPREPRO_CODENAME}" `
+		"${env:PROJECT_DEBIAN_DISTRIBUTION}" `
+		"${__keyring}"
+	if ($__process -ne 0) {
+		return 1
+	}
 
 
 	# report status

--- a/srcC/.ci/_package-deb_unix-any.sh
+++ b/srcC/.ci/_package-deb_unix-any.sh
@@ -36,6 +36,7 @@ PACKAGE::assemble_deb_content() {
 
 
         # validate target before job
+        __keyring="$PROJECT_SKU"
         if [ $(FS::is_target_a_source "$__target") -eq 0 ]; then
                 return 10 # not applicable
         elif [ $(FS::is_target_a_library "$__target") -eq 0 ]; then
@@ -86,29 +87,26 @@ PACKAGE::assemble_deb_content() {
                 fi
         fi
 
-        OS::print_status info "overriding source.list file...\n"
-        __url="${PROJECT_STATIC_URL}/deb"
-        if [ -z "$__keyring" ]; then
-                __keyring="$PROJECT_SKU"
-        fi
-        DEB::create_source_list \
-                "$PROJECT_SIMULATE_RELEASE_REPO" \
-                "$__directory" \
-                "$PROJECT_GPG_ID" \
-                "${__url%//deb*}/deb" \
-                "$PROJECT_REPREPRO_CODENAME" \
-                "$PROJECT_DEBIAN_DISTRIBUTION" \
-                "$__keyring"
-        if [ $? -ne 0 ]; then
-                return 1
-        fi
-
 
         # OPTIONAL (overrides): copy usr/share/docs/${PROJECT_SKU}/changelog.gz
         # OPTIONAL (overrides): copy usr/share/docs/${PROJECT_SKU}/copyright.gz
         # OPTIONAL (overrides): copy usr/share/man/man1/${PROJECT_SKU}.1.gz
         # OPTIONAL (overrides): generate ${__directory}/control/md5sum
         # OPTIONAL (overrides): generate ${__directory}/control/control
+
+
+        OS::print_status info "creating source.list files...\n"
+        DEB::create_source_list \
+                "$PROJECT_SIMULATE_RELEASE_REPO" \
+                "$__directory" \
+                "$PROJECT_GPG_ID" \
+                "$PROJECT_STATIC_URL" \
+                "$PROJECT_REPREPRO_CODENAME" \
+                "$PROJECT_DEBIAN_DISTRIBUTION" \
+                "$__keyring"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
 
 
         # report status

--- a/srcC/.ci/_package-deb_windows-any.ps1
+++ b/srcC/.ci/_package-deb_windows-any.ps1
@@ -35,7 +35,9 @@ function PACKAGE-Assemble-DEB-Content {
 		[string]$__target_arch
 	)
 
+
 	# validate target before job
+	$__keyring = "${env:PROJECT_SKU}"
 	if ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
 		return 10 # not applicable
 	} elseif ($(FS-Is-Target-A-Library "${__target}") -eq 0) {
@@ -84,32 +86,27 @@ function PACKAGE-Assemble-DEB-Content {
 		}
 	}
 
-	OS-Print-Status info "overriding source.list file..."
-	if ([string]::IsNullOrEmpty($__keyring)) {
-		$__keyring = "${env:PROJECT_SKU}"
-	}
-
-	$__url = "${env:PROJECT_STATIC_URL}/deb"
-	$__url = $__url -replace "//deb", "/deb"
-	$__process = DEB-Create-Source-List `
-		"${env:PROJECT_DEBIAN_CREATE_SOURCE_LIST}" `
-		"${env:PROJECT_SIMULATE_RELEASE_REPO}" `
-		"${__directory}" `
-		"${env:PROJECT_GPG_ID}" `
-		"${__url}" `
-		"${env:PROJECT_REPREPRO_CODENAME}" `
-		"${env:PROJECT_DEBIAN_DISTRIBUTION}" `
-		"${__keyring}"
-	if ($__process -ne 0) {
-		return 1
-	}
-
 
 	# OPTIONAL (overrides): copy usr/share/docs/${env:PROJECT_SKU}/changelog.gz
 	# OPTIONAL (overrides): copy usr/share/docs/${env:PROJECT_SKU}/copyright.gz
 	# OPTIONAL (overrides): copy usr/share/man/man1/${env:PROJECT_SKU}.1.gz
 	# OPTIONAL (overrides): generate ${__directory}/control/md5sum
 	# OPTIONAL (overrides): generate ${__directory}/control/control
+
+
+	OS-Print-Status info "creating source.list files..."
+	$__process = DEB-Create-Source-List `
+		"${env:PROJECT_DEBIAN_CREATE_SOURCE_LIST}" `
+		"${env:PROJECT_SIMULATE_RELEASE_REPO}" `
+		"${__directory}" `
+		"${env:PROJECT_GPG_ID}" `
+		"${env:PROJECT_STATIC_URL}" `
+		"${env:PROJECT_REPREPRO_CODENAME}" `
+		"${env:PROJECT_DEBIAN_DISTRIBUTION}" `
+		"${__keyring}"
+	if ($__process -ne 0) {
+		return 1
+	}
 
 
 	# report status

--- a/srcC/.ci/_package-rpm_unix-any.sh
+++ b/srcC/.ci/_package-rpm_unix-any.sh
@@ -35,7 +35,7 @@ PACKAGE::assemble_rpm_content() {
 
 
         # validate target before job
-        FS::is_target_a_source "$__target"
+        __keyring="$PROJECT_SKU"
         if [ $(FS::is_target_a_source "$__target") -eq 0 ]; then
                 return 10
         elif [ $(FS::is_target_a_library "$__target") -eq 0 ]; then
@@ -76,6 +76,8 @@ install -m 0644 copyright %{buildroot}/usr/local/share/doc/lib${PROJECT_SKU}/
                 if [ $? -ne 0 ]; then
                         return 1
                 fi
+
+                __keyring="lib$PROJECT_SKU"
         elif [ $(FS::is_target_a_wasm_js "$__target") -eq 0 ]; then
                 return 10 # not applicable
         elif [ $(FS::is_target_a_wasm "$__target") -eq 0 ]; then
@@ -127,6 +129,19 @@ install -m 0644 ${PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
         # OPTIONAL (overrides): ${__directory}/BUILD/copyright.gz
         # OPTIONAL (overrides): ${__directory}/BUILD/man.1.gz
         # OPTIONAL (overrides): ${__directory}/SPECS/${PROJECT_SKU}.spec
+
+
+        OS::print_status info "creating source.repo files...\n"
+        RPM::create_source_repo \
+                "$PROJECT_SIMULATE_RELEASE_REPO" \
+                "$__directory" \
+                "$PROJECT_GPG_ID" \
+                "$PROJECT_STATIC_URL" \
+                "$PROJECT_NAME" \
+                "$__keyring"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
 
 
         # report status

--- a/srcC/.ci/_package-rpm_windows-any.ps1
+++ b/srcC/.ci/_package-rpm_windows-any.ps1
@@ -36,6 +36,7 @@ function PACKAGE-Assemble-RPM-Content {
 
 
 	# validate target before job
+	$__keyring = "${env:PROJECT_SKU}"
 	if ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
 		return 10 # not applicable
 	} elseif ($(FS-Is-Target-A-Library "${__target}") -eq 0) {
@@ -76,6 +77,8 @@ install -m 0644 copyright %{buildroot}/usr/local/share/doc/lib${env:PROJECT_SKU}
 		if ($__process -ne 0) {
 			return 1
 		}
+
+		$__keyring = "lib${env:PROJECT_SKU}"
 	} elseif ($(FS-Is-Target-A-WASM-JS "${__target}") -eq 0) {
 		return 10 # not applicable
 	} elseif ($(FS-Is-Target-A-WASM "${__target}") -eq 0) {
@@ -135,6 +138,20 @@ install -m 644 ${env:PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
 	# OPTIONAL (overrides): ${__directory}/BUILD/copyright.gz
 	# OPTIONAL (overrides): ${__directory}/BUILD/man.1.gz
 	# OPTIONAL (overrides): ${__directory}/SPECS/${env:PROJECT_SKU}.spec
+
+
+	OS-Print-Status info "creating source.repo files..."
+	$__process = RPM-Create-Source-Repo `
+		"${env:PROJECT_SIMULATE_RELEASE_REPO}" `
+		"${__directory}" `
+		"${env:PROJECT_GPG_ID}" `
+		"${env:PROJECT_STATIC_URL}" `
+		"${env:PROJECT_REPREPRO_CODENAME}" `
+		"${env:PROJECT_DEBIAN_DISTRIBUTION}" `
+		"${__keyring}"
+	if ($__process -ne 0) {
+		return 1
+	}
 
 
 	# report status


### PR DESCRIPTION
To close the distribution ecosystem for .rpm, we should add an rpm's source.repo file generator function to autonomously setup its GPG key and source location. That way, folks can automatically get update from the upstream. Hence, let's do this.

This patch adds yum's source.repo file gneerator function into root repository.