### PR TITLE
srcPYTHON: enabled Homebrew for Python programming language

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -126,7 +126,7 @@ PROJECT_PATH_GO_ENGINE = "go-engine"
 #
 # To enable it: simply supply the path (e.g. default is 'srcC').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_C = 'srcC'
+PROJECT_C = ''
 
 
 
@@ -143,7 +143,7 @@ PROJECT_C = 'srcC'
 #
 # To enable it: simply supply the path (e.g. default is 'srcPYTHON').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_PYTHON = ''
+PROJECT_PYTHON = 'srcPYTHON'
 
 
 # PROJECT_PATH_PYTHON_ENGINE

--- a/src/changelog/data/latest
+++ b/src/changelog/data/latest
@@ -1,3 +1,4 @@
+srcC: applied development regression from srcGO porting
 srcGO: enabled Homebrew for Go programming language
 root: added homebrew ecosystem support
 root: updated repository metadata

--- a/src/changelog/deb/latest
+++ b/src/changelog/deb/latest
@@ -1,5 +1,6 @@
 automataci (1.6.0) stable; urgency=low
 
+  * srcC: applied development regression from srcGO porting
   * srcGO: enabled Homebrew for Go programming language
   * root: added homebrew ecosystem support
   * root: updated repository metadata
@@ -15,4 +16,4 @@ automataci (1.6.0) stable; urgency=low
   * root: added C Programming Language support
   * README.md: corrected typo
 
--- Your Legal Full Name Here <contact@youremail.example>  Sat, 07 Oct 2023 21:44:06 +0800
+-- Your Legal Full Name Here <contact@youremail.example>  Sun, 08 Oct 2023 08:27:06 +0800

--- a/srcC/.ci/_package-archive_unix-any.sh
+++ b/srcC/.ci/_package-archive_unix-any.sh
@@ -59,8 +59,7 @@ PACKAGE::assemble_archive_content() {
 
                 FS::is_file "${_target%.wasm*}.js"
                 if [ $? -eq 0 ]; then
-                        OS::print_status info \
-                                "copying ${_target%.wasm*}.js to ${_directory}\n"
+                        OS::print_status info "copying ${_target%.wasm*}.js to ${_directory}\n"
                         FS::copy_file "${_target%.wasm*}.js" "$_directory"
                         if [ $? -ne 0 ]; then
                                 return 1

--- a/srcGO/.ci/_package-archive_unix-any.sh
+++ b/srcGO/.ci/_package-archive_unix-any.sh
@@ -70,8 +70,7 @@ replace ${PROJECT_SKU} => ./
 
                 FS::is_file "${_target%.wasm*}.js"
                 if [ $? -eq 0 ]; then
-                        OS::print_status info \
-                                "copying ${_target%.wasm*}.js to ${_directory}\n"
+                        OS::print_status info "copying ${_target%.wasm*}.js to ${_directory}\n"
                         FS::copy_file "${_target%.wasm*}.js" "$_directory"
                         if [ $? -ne 0 ]; then
                                 return 1

--- a/srcGO/.ci/_package-archive_windows-any.ps1
+++ b/srcGO/.ci/_package-archive_windows-any.ps1
@@ -81,9 +81,9 @@ replace ${env:PROJECT_SKU} => ./
 	} else {
 		switch (${_target_os}) {
 		"windows" {
-			$__dest = "${_directory}\${env:PROJECT_SKU}.exe"
+			$_dest = "${_directory}\${env:PROJECT_SKU}.exe"
 		} Default {
-			$__dest = "${_directory}\${env:PROJECT_SKU}"
+			$_dest = "${_directory}\${env:PROJECT_SKU}"
 		}}
 
 		OS-Print-Status info "copying ${_target} to ${_dest}"

--- a/srcPYTHON/.ci/_package-archive_unix-any.sh
+++ b/srcPYTHON/.ci/_package-archive_unix-any.sh
@@ -28,57 +28,58 @@ fi
 
 
 PACKAGE::assemble_archive_content() {
-        __target="$1"
-        __directory="$2"
-        __target_name="$3"
-        __target_os="$4"
-        __target_arch="$5"
+        _target="$1"
+        _directory="$2"
+        _target_name="$3"
+        _target_os="$4"
+        _target_arch="$5"
 
 
         # package based on target's nature
-        if [ $(FS::is_target_a_source "$__target") -eq 0 ]; then
+        if [ $(FS::is_target_a_source "$_target") -eq 0 ]; then
                 # it's a source target
-                __target="${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/Libs"
-                PYTHON::clean_artifact "$__target"
-                OS::print_status info "copying ${__target} to ${__directory}\n"
-                FS::copy_all "$__target" "$__directory"
+                _target="${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/Libs"
+                PYTHON::clean_artifact "$_target"
+                OS::print_status info "copying ${_target} to ${_directory}\n"
+                FS::copy_all "$_target" "$_directory"
                 if [ $? -ne 0 ]; then
                         OS::print_status error "copy failed."
                         return 1
                 fi
-        elif [ $(FS::is_target_a_library "$__target") -eq 0 ]; then
+        elif [ $(FS::is_target_a_library "$_target") -eq 0 ]; then
                 return 10 # not applicable
-        elif [ $(FS::is_target_a_wasm_js "$__target") -eq 0 ]; then
+        elif [ $(FS::is_target_a_wasm_js "$_target") -eq 0 ]; then
                 return 10 # handled by wasm instead
-        elif [ $(FS::is_target_a_wasm "$__target") -eq 0 ]; then
-                OS::print_status info "copying ${__target} to ${__directory}\n"
-                FS::copy_file "$__target" "$__directory"
+        elif [ $(FS::is_target_a_wasm "$_target") -eq 0 ]; then
+                OS::print_status info "copying ${_target} to ${_directory}\n"
+                FS::copy_file "$_target" "$_directory"
                 if [ $? -ne 0 ]; then
                         return 1
                 fi
 
-                FS::is_file "${__target%.wasm*}.js"
+                FS::is_file "${_target%.wasm*}.js"
                 if [ $? -eq 0 ]; then
-                        OS::print_status info \
-                                "copying ${__target%.wasm*}.js to ${__directory}\n"
-                        FS::copy_file "${__target%.wasm*}.js" "$__directory"
+                        OS::print_status info "copying ${_target%.wasm*}.js to ${_directory}\n"
+                        FS::copy_file "${_target%.wasm*}.js" "$_directory"
                         if [ $? -ne 0 ]; then
                                 return 1
                         fi
                 fi
+        elif [ $(FS::is_target_a_homebrew "$_target") -eq 0 ]; then
+                return 10 # not applicable
         else
                 # it's a binary target
-                case "$__target_os" in
+                case "$_target_os" in
                 windows)
-                        __dest="${__directory}/${PROJECT_SKU}.exe"
+                        _dest="${_directory}/${PROJECT_SKU}.exe"
                         ;;
                 *)
-                        __dest="${__directory}/${PROJECT_SKU}"
+                        _dest="${_directory}/${PROJECT_SKU}"
                         ;;
                 esac
 
-                OS::print_status info "copying ${__target} to ${__dest}\n"
-                FS::copy_file "$__target" "$__dest"
+                OS::print_status info "copying ${_target} to ${_dest}\n"
+                FS::copy_file "$_target" "$_dest"
                 if [ $? -ne 0 ]; then
                         OS::print_status error "copy failed."
                         return 1
@@ -87,9 +88,9 @@ PACKAGE::assemble_archive_content() {
 
 
         # copy user guide
-        __target="${PROJECT_PATH_ROOT}/${PROJECT_PATH_RESOURCES}/docs/USER-GUIDES-EN.pdf"
-        OS::print_status info "copying ${__target} to ${__directory}\n"
-        FS::copy_file "$__target" "${__directory}/."
+        _target="${PROJECT_PATH_ROOT}/${PROJECT_PATH_RESOURCES}/docs/USER-GUIDES-EN.pdf"
+        OS::print_status info "copying ${_target} to ${_directory}\n"
+        FS::copy_file "$_target" "${_directory}/."
         if [ $? -ne 0 ]; then
                 OS::print_status error "copy failed."
                 return 1
@@ -97,9 +98,9 @@ PACKAGE::assemble_archive_content() {
 
 
         # copy license file
-        __target="${PROJECT_PATH_ROOT}/${PROJECT_PATH_RESOURCES}/licenses/LICENSE-EN.pdf"
-        OS::print_status info "copying ${__target} to ${__directory}\n"
-        FS::copy_file "$__target" "${__directory}/."
+        _target="${PROJECT_PATH_ROOT}/${PROJECT_PATH_RESOURCES}/licenses/LICENSE-EN.pdf"
+        OS::print_status info "copying ${_target} to ${_directory}\n"
+        FS::copy_file "$_target" "${_directory}/."
         if [ $? -ne 0 ]; then
                 OS::print_status error "copy failed."
                 return 1

--- a/srcPYTHON/.ci/_package-archive_windows-any.ps1
+++ b/srcPYTHON/.ci/_package-archive_windows-any.ps1
@@ -28,56 +28,58 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 
 function PACKAGE-Assemble-Archive-Content {
 	param(
-		[string]$__target,
-		[string]$__directory,
-		[string]$__target_name,
-		[string]$__target_os,
-		[string]$__target_arch
+		[string]$_target,
+		[string]$_directory,
+		[string]$_target_name,
+		[string]$_target_os,
+		[string]$_target_arch
 	)
 
 
 	# copy main program
-	if ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
-		$__target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\Libs"
-		PYTHON-Clean-Artifact "${__target}"
-		OS-Print-Status info "copying ${__target} to ${__directory}"
-		$__process = FS-Copy-All "${__target}" "${__directory}"
+	if ($(FS-Is-Target-A-Source "${_target}") -eq 0) {
+		$_target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\Libs"
+		$null = PYTHON-Clean-Artifact "${_target}"
+		OS-Print-Status info "copying ${_target} to ${_directory}"
+		$__process = FS-Copy-All "${_target}" "${_directory}"
 		if ($__process -ne 0) {
 			OS-Print-Status error "copy failed."
 			return 1
 		}
-	} elseif ($(FS-Is-Target-A-Library "${__target}") -eq 0) {
+	} elseif ($(FS-Is-Target-A-Library "${_target}") -eq 0) {
 		return 10 # not applicable
-	} elseif ($(FS-Is-Target-A-WASM-JS "${__target}") -eq 0) {
+	} elseif ($(FS-Is-Target-A-WASM-JS "${_target}") -eq 0) {
 		return 10 # handled by wasm instead
-	} elseif ($(FS-Is-Target-A-WASM "${__target}") -eq 0) {
-		OS-Print-Status info "copying ${__target} to ${__directory}"
-		$__process = Fs-Copy-File "${__target}" "${__directory}"
+	} elseif ($(FS-Is-Target-A-WASM "${_target}") -eq 0) {
+		OS-Print-Status info "copying ${_target} to ${_directory}"
+		$__process = Fs-Copy-File "${_target}" "${_directory}"
 		if ($__process -ne 0) {
 			return 1
 		}
 
-		$__process = FS-Is-File "$($__target -replace '\.wasm.*$', '.js')"
+		$__process = FS-Is-File "$($_target -replace '\.wasm.*$', '.js')"
 		if ($__process -eq 0) {
 			OS-Print-Status info `
-				"copying $($__target -replace '\.wasm.*$', '.js') to ${__directory}"
+				"copying $($_target -replace '\.wasm.*$', '.js') to ${_directory}"
 			$__process = Fs-Copy-File `
-					"$($__target -replace '\.wasm.*$', '.js')" `
-					"${__directory}"
+					"$($_target -replace '\.wasm.*$', '.js')" `
+					"${_directory}"
 			if ($__process -ne 0) {
 				return 1
 			}
 		}
+	} elseif ($(FS-Is-Target-A-Homebrew "${_target}") -eq 0) {
+		return 10 # not applicable
 	} else {
-		switch (${__target_os}) {
+		switch (${_target_os}) {
 		"windows" {
-			$__dest = "${__directory}\${env:PROJECT_SKU}.exe"
+			$_dest = "${_directory}\${env:PROJECT_SKU}.exe"
 		} Default {
-			$__dest = "${__directory}\${env:PROJECT_SKU}"
+			$_dest = "${_directory}\${env:PROJECT_SKU}"
 		}}
 
-		OS-Print-Status info "copying ${__target} to ${__dest}"
-		$__process = Fs-Copy-File "${__target}" "${__dest}"
+		OS-Print-Status info "copying ${_target} to ${_dest}"
+		$__process = Fs-Copy-File "${_target}" "${_dest}"
 		if ($__process -ne 0) {
 			OS-Print-Status error "copy failed."
 			return 1
@@ -86,9 +88,9 @@ function PACKAGE-Assemble-Archive-Content {
 
 
 	# copy user guide
-	$__target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\docs\USER-GUIDES-EN.pdf"
-	OS-Print-Status info "copying ${__target} to ${__directory}"
-	$__process = FS-Copy-File "${__target}" "${__directory}"
+	$_target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\docs\USER-GUIDES-EN.pdf"
+	OS-Print-Status info "copying ${_target} to ${_directory}"
+	$__process = FS-Copy-File "${_target}" "${_directory}"
 	if ($__process -ne 0) {
 		OS-Print-Status error "copy failed."
 		return 1
@@ -96,9 +98,9 @@ function PACKAGE-Assemble-Archive-Content {
 
 
 	# copy license file
-	$__target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\licenses\LICENSE-EN.pdf"
-	OS-Print-Status info "copying ${__target} to ${__directory}"
-	$__process = FS-Copy-File "${__target}" "${__directory}"
+	$_target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\licenses\LICENSE-EN.pdf"
+	OS-Print-Status info "copying ${_target} to ${_directory}"
+	$__process = FS-Copy-File "${_target}" "${_directory}"
 	if ($__process -ne 0) {
 		OS-Print-Status error "copy failed."
 		return 1

--- a/srcPYTHON/.ci/_package-docker_unix-any.sh
+++ b/srcPYTHON/.ci/_package-docker_unix-any.sh
@@ -27,25 +27,27 @@ fi
 
 
 PACKAGE::assemble_docker_content() {
-        __target="$1"
-        __directory="$2"
-        __target_name="$3"
-        __target_os="$4"
-        __target_arch="$5"
+        _target="$1"
+        _directory="$2"
+        _target_name="$3"
+        _target_os="$4"
+        _target_arch="$5"
 
 
         # validate project
-        if [ $(FS::is_target_a_source "$__target") -eq 0 ]; then
+        if [ $(FS::is_target_a_source "$_target") -eq 0 ]; then
                 return 10 # not applicable
-        elif [ $(FS::is_target_a_library "$__target") -eq 0 ]; then
+        elif [ $(FS::is_target_a_library "$_target") -eq 0 ]; then
                 return 10 # not applicable
-        elif [ $(FS::is_target_a_wasm_js "$__target") -eq 0 ]; then
+        elif [ $(FS::is_target_a_wasm_js "$_target") -eq 0 ]; then
                 return 10 # not applicable
-        elif [ $(FS::is_target_a_wasm "$__target") -eq 0 ]; then
+        elif [ $(FS::is_target_a_wasm "$_target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_homebrew "$_target") -eq 0 ]; then
                 return 10 # not applicable
         fi
 
-        case "$__target_os" in
+        case "$_target_os" in
         linux|windows)
                 ;;
         *)
@@ -57,32 +59,32 @@ PACKAGE::assemble_docker_content() {
 
 
         # assemble the package
-        FS::copy_file "$__target" "${__directory}/${PROJECT_SKU}"
+        FS::copy_file "$_target" "${_directory}/${PROJECT_SKU}"
         if [ $? -ne 0 ]; then
                 return 1
         fi
 
-        FS::touch_file "${__directory}/.blank"
+        FS::touch_file "${_directory}/.blank"
         if [ $? -ne 0 ]; then
                 return 1
         fi
 
 
         # generate the Dockerfile
-        FS::write_file "${__directory}/Dockerfile" "\
+        FS::write_file "${_directory}/Dockerfile" "\
 # Defining baseline image
 "
-        if [ "$__target_os" = "windows" ]; then
-                FS::append_file "${__directory}/Dockerfile" "\
-FROM --platform=${__target_os}/${__target_arch} mcr.microsoft.com/windows/nanoserver:ltsc2022
+        if [ "$_target_os" = "windows" ]; then
+                FS::append_file "${_directory}/Dockerfile" "\
+FROM --platform=${_target_os}/${_target_arch} mcr.microsoft.com/windows/nanoserver:ltsc2022
 "
         else
-                FS::append_file "${__directory}/Dockerfile" "\
-FROM --platform=${__target_os}/${__target_arch} linuxcontainers/debian-slim:latest
+                FS::append_file "${_directory}/Dockerfile" "\
+FROM --platform=${_target_os}/${_target_arch} linuxcontainers/debian-slim:latest
 "
         fi
 
-        FS::append_file "${__directory}/Dockerfile" "\
+        FS::append_file "${_directory}/Dockerfile" "\
 LABEL org.opencontainers.image.title=\"${PROJECT_NAME}\"
 LABEL org.opencontainers.image.description=\"${PROJECT_PITCH}\"
 LABEL org.opencontainers.image.authors=\"${PROJECT_CONTACT_NAME} <${PROJECT_CONTACT_EMAIL}>\"
@@ -92,21 +94,21 @@ LABEL org.opencontainers.image.licenses=\"${PROJECT_LICENSE}\"
 "
 
         if [ ! -z "$PROJECT_CONTACT_WEBSITE" ]; then
-                FS::append_file "${__directory}/Dockerfile" "\
+                FS::append_file "${_directory}/Dockerfile" "\
 LABEL org.opencontainers.image.url=\"${PROJECT_CONTACT_WEBSITE}\"
 "
         fi
 
         if [ ! -z "$PROJECT_SOURCE_URL" ]; then
-                FS::append_file "${__directory}/Dockerfile" "\
+                FS::append_file "${_directory}/Dockerfile" "\
 LABEL org.opencontainers.image.source=\"${PROJECT_SOURCE_URL}\"
 "
         fi
 
-        FS::append_file "${__directory}/Dockerfile" "\
+        FS::append_file "${_directory}/Dockerfile" "\
 # Defining environment variables
-ENV ARCH ${__target_arch}
-ENV OS ${__target_os}
+ENV ARCH ${_target_arch}
+ENV OS ${_target_os}
 ENV PORT 80
 
 # Assemble the file structure

--- a/srcPYTHON/.ci/_package-docker_windows-any.ps1
+++ b/srcPYTHON/.ci/_package-docker_windows-any.ps1
@@ -27,26 +27,28 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 
 function PACKAGE-Assemble-DOCKER-Content {
 	param (
-		[string]$__target,
-		[string]$__directory,
-		[string]$__target_name,
-		[string]$__target_os,
-		[string]$__target_arch
+		[string]$_target,
+		[string]$_directory,
+		[string]$_target_name,
+		[string]$_target_os,
+		[string]$_target_arch
 	)
 
 
 	# validate project
-	if ($(FS-Is-Target-A-Source "${__target}") -eq 0) {
+	if ($(FS-Is-Target-A-Source "${_target}") -eq 0) {
 		return 10 # not applicable
-	} elseif ($(FS-Is-Target-A-Library "${__target}") -eq 0) {
+	} elseif ($(FS-Is-Target-A-Library "${_target}") -eq 0) {
 		return 10 # not applicable
-	} elseif ($(FS-Is-Target-A-WASM-JS "${__target}") -eq 0) {
+	} elseif ($(FS-Is-Target-A-WASM-JS "${_target}") -eq 0) {
 		return 10 # not applicable
-	} elseif ($(FS-Is-Target-A-WASM "${__target}") -eq 0) {
+	} elseif ($(FS-Is-Target-A-WASM "${_target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-Homebrew "${_target}") -eq 0) {
 		return 10 # not applicable
 	}
 
-	switch ($__target_os) {
+	switch ($_target_os) {
 	{ $_ -in 'linux', 'windows' } {
 		# accepted
 	} default {
@@ -57,32 +59,32 @@ function PACKAGE-Assemble-DOCKER-Content {
 
 
 	# assemble the package
-	$__process = FS-Copy-File "${__target}" "${__directory}\${env:PROJECT_SKU}"
+	$__process = FS-Copy-File "${_target}" "${_directory}\${env:PROJECT_SKU}"
 	if ($__process -ne 0) {
 		return 1
 	}
 
-	$__process = FS-Touch-File "${__directory}\.blank"
+	$__process = FS-Touch-File "${_directory}\.blank"
 	if ($__process -ne 0) {
 		return 1
 	}
 
 
 	# generate the Dockerfile
-	$__process = FS-Write-File "${__directory}\Dockerfile" @"
+	$__process = FS-Write-File "${_directory}\Dockerfile" @"
 # Defining baseline image
 "@
-	if (${__target_os} == "windows") {
-		$__process = FS-Append-File "${__directory}\Dockerfile" @"
-FROM --platform=${__target_os}/${__target_arch} mcr.microsoft.com/windows/nanoserver:ltsc2022
+	if (${_target_os} == "windows") {
+		$__process = FS-Append-File "${_directory}\Dockerfile" @"
+FROM --platform=${_target_os}/${_target_arch} mcr.microsoft.com/windows/nanoserver:ltsc2022
 "@
 	} else {
-		$__process = FS-Append-File "${__directory}\Dockerfile" @"
-FROM --platform=${__target_os}/${__target_arch} linuxcontainers/debian-slim:latest
+		$__process = FS-Append-File "${_directory}\Dockerfile" @"
+FROM --platform=${_target_os}/${_target_arch} linuxcontainers/debian-slim:latest
 "@
 	}
 
-	$__process = FS-Append-File "${__directory}\Dockerfile" @"
+	$__process = FS-Append-File "${_directory}\Dockerfile" @"
 LABEL org.opencontainers.image.title=`"${env:PROJECT_NAME}`"
 LABEL org.opencontainers.image.description=`"${env:PROJECT_PITCH}`"
 LABEL org.opencontainers.image.authors=`"${env:PROJECT_CONTACT_NAME} <${env:PROJECT_CONTACT_EMAIL}>`"
@@ -92,32 +94,32 @@ LABEL org.opencontainers.image.licenses=`"${env:PROJECT_LICENSE}`"
 "@
 
 	if (-not ([string]::IsNullOrEmpty(${env:PROJECT_CONTACT_WEBSITE}))) {
-		$__process = FS-Append-File "${__directory}\Dockerfile" @"
+		$__process = FS-Append-File "${_directory}\Dockerfile" @"
 LABEL org.opencontainers.image.url=`"${env:PROJECT_CONTACT_WEBSITE}`"
 "@
 	}
 
 	if (-not ([string]::IsNullOrEmpty(${env:PROJECT_SOURCE_URL}))) {
-		$__process = FS-Append-File "${__directory}\Dockerfile" @"
+		$__process = FS-Append-File "${_directory}\Dockerfile" @"
 LABEL org.opencontainers.image.source=`"${env:PROJECT_SOURCE_URL}`"
 "@
 	}
 
-	$__process = FS-Append-File "${__directory}\Dockerfile" @"
+	$__process = FS-Append-File "${_directory}\Dockerfile" @"
 # Defining environment variables
-ENV ARCH ${__target_arch}
-ENV OS ${__target_os}
+ENV ARCH ${_target_arch}
+ENV OS ${_target_os}
 ENV PORT 80
 
 # Assemble the file structure
 COPY .blank /tmp/.tmpfile
-ADD ${PROJECT_SKU} /app/bin/${PROJECT_SKU}
+ADD ${env:PROJECT_SKU} /app/bin/${env:PROJECT_SKU}
 
 # Set network port exposures
 EXPOSE 80
 
 # Set entry point
-ENTRYPOINT ["/app/bin/${PROJECT_SKU}"]
+ENTRYPOINT ["/app/bin/${env:PROJECT_SKU}"]
 "@
 	if ($__process -ne 0) {
 		return 1

--- a/srcPYTHON/.ci/_package-homebrew_unix-any.sh
+++ b/srcPYTHON/.ci/_package-homebrew_unix-any.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+
+
+
+# initialize
+if [ "$PROJECT_PATH_ROOT" == "" ]; then
+        >&2 printf "[ ERROR ] - Please run from ci.cmd instead!\n"
+        return 1
+fi
+
+. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
+. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
+. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/strings.sh"
+. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/python.sh"
+
+
+
+
+PACKAGE::assemble_homebrew_content() {
+        _target="$1"
+        _directory="$2"
+        _target_name="$3"
+        _target_os="$4"
+        _target_arch="$5"
+
+
+        # validate project
+        if [ $(FS::is_target_a_source "$_target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_library "$_target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_wasm_js "$_target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_wasm "$_target") -eq 0 ]; then
+                return 10 # not applicable
+        elif [ $(FS::is_target_a_homebrew "$_target") -eq 0 ]; then
+                : # accepted
+        else
+                return 10 # not applicable
+        fi
+
+
+        # assemble the package
+        FS::make_directory "${_directory}/Data/${PROJECT_PATH_SOURCE}"
+        FS::copy_all "${PROJECT_PATH_ROOT}/${PROJECT_PATH_SOURCE}/" \
+                        "${_directory}/Data/${PROJECT_PATH_SOURCE}"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        PYTHON::clean_artifact "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}"
+        FS::copy_all "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}" "${_directory}/Data"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        FS::copy_all "${PROJECT_PATH_ROOT}/automataCI" "${_directory}/Data"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        FS::copy_file "${PROJECT_PATH_ROOT}/CONFIG.toml" "${_directory}/Data"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        FS::copy_file "${PROJECT_PATH_ROOT}/ci.cmd" "${_directory}/Data"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+
+        # script formula.rb
+        OS::print_status info "scripting formula.rb...\n"
+        FS::write_file "${_directory}/formula.rb" "\
+class ${PROJECT_SKU_TITLECASE} < Formula
+  desc \"${PROJECT_PITCH}\"
+  homepage \"${PROJECT_CONTACT_WEBSITE}\"
+  license \"${PROJECT_LICENSE}\"
+  url \"${PROJECT_HOMEBREW_SOURCE_URL}/${PROJECT_VERSION}/{{ TARGET_PACKAGE }}\"
+  sha256 \"{{ TARGET_SHASUM }}\"
+
+
+  depends_on \"go\" => [:build, :test]
+
+  def install
+    system \"./ci.cmd setup\"
+    system \"./ci.cmd prepare\"
+    system \"./ci.cmd materialize\"
+    chmod 0755, \"bin/${PROJECT_SKU}\"
+    bin.install \"bin/${PROJECT_SKU}\"
+  end
+
+  test do
+    system \"./ci.cmd setup\"
+    system \"./ci.cmd prepare\"
+    system \"./ci.cmd materialize\"
+    assert_predicate ./bin/${PROJECT_SKU}, :exist?
+  end
+end
+"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+
+        # report status
+        return 0
+}

--- a/srcPYTHON/.ci/_package-homebrew_windows-any.ps1
+++ b/srcPYTHON/.ci/_package-homebrew_windows-any.ps1
@@ -1,0 +1,121 @@
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#               http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+
+
+# initialize
+if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
+	Write-Error "[ ERROR ] - Please run from ci.cmd instead!\n"
+	exit 1
+}
+
+. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\os.ps1"
+. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
+. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\strings.ps1"
+. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\compilers\python.ps1"
+
+
+
+
+function PACKAGE-Assemble-HOMEBREW-Content {
+	param (
+		[string]$_target,
+		[string]$_directory,
+		[string]$_target_name,
+		[string]$_target_os,
+		[string]$_target_arch
+	)
+
+
+	# validate project
+	if ($(FS-Is-Target-A-Source "${_target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-Library "${_target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-WASM-JS "${_target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-WASM "${_target}") -eq 0) {
+		return 10 # not applicable
+	} elseif ($(FS-Is-Target-A-Homebrew "${_target}") -eq 0) {
+		# accepted
+	} else {
+		return 10 # not applicable
+	}
+
+
+	# assemble the package
+	$null = FS-Make-Directory "${_directory}\Data\${env:PROJECT_PATH_SOURCE}"
+	$__process = FS-Copy-All "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_SOURCE}" `
+		"${_directory}\Data\${env:PROJECT_PATH_SOURCE}"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	$null = PYTHON-Clean-Artifact "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}"
+	$__process = FS-Copy-All "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}" "${_directory}"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	$__process = FS-Copy-All "${env:PROJECT_PATH_ROOT}\automataCI" "${_directory}"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	$__process = FS-Copy-File "${env:PROJECT_PATH_ROOT}\CONFIG.toml" "${_directory}"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+	$__process = FS-Copy-File "${env:PROJECT_PATH_ROOT}\ci.cmd" "${_directory}"
+	if ($__process -ne 0) {
+		return 1
+	}
+
+
+	# script formula.rb
+	OS-Print-Status info "scripting formula.rb..."
+	$__process = FS-Write-File "${_directory}\formula.rb" @"
+class ${env:PROJECT_SKU_TITLECASE} < Formula
+  desc "${env:PROJECT_PITCH}"
+  homepage "${env:PROJECT_CONTACT_WEBSITE}"
+  license "${env:PROJECT_LICENSE}"
+  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/${env:PROJECT_VERSION}/{{ TARGET_PACKAGE }}"
+  sha256 "{{ TARGET_SHASUM }}"
+
+  depends_on "go" => [:build, :test]
+
+  def install
+    system "./ci.cmd setup"
+    system "./ci.cmd prepare"
+    system "./ci.cmd materialize"
+    chmod 0755, "bin/${env:PROJECT_SKU}"
+    bin.install "bin/${env:PROJECT_SKU}"
+  end
+
+  test do
+    system "./ci.cmd setup"
+    system "./ci.cmd prepare"
+    system "./ci.cmd materialize"
+    assert_predicate ./bin/${env:PROJECT_SKU}, :exist?
+  end
+end
+"@
+	if ($__process -ne 0) {
+		return 1
+	}
+
+
+	# report status
+	return 0
+}

--- a/srcPYTHON/.ci/_package-pypi_unix-any.sh
+++ b/srcPYTHON/.ci/_package-pypi_unix-any.sh
@@ -27,15 +27,15 @@ fi
 
 
 PACKAGE::assemble_pypi_content() {
-        __target="$1"
-        __directory="$2"
-        __target_name="$3"
-        __target_os="$4"
-        __target_arch="$5"
+        _target="$1"
+        _directory="$2"
+        _target_name="$3"
+        _target_os="$4"
+        _target_arch="$5"
 
 
         # validate project
-        FS::is_target_a_source "$__target"
+        FS::is_target_a_source "$_target"
         if [ $? -ne 0 ]; then
                 return 10
         fi
@@ -47,21 +47,21 @@ PACKAGE::assemble_pypi_content() {
 
         # assemble the python package
         PYTHON::clean_artifact "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/"
-        FS::copy_all "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/Libs/" "${__directory}"
+        FS::copy_all "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/Libs/" "${_directory}"
         if [ $? -ne 0 ]; then
                 return 1
         fi
 
         FS::copy_file \
                 "${PROJECT_PATH_ROOT}/${PROJECT_PYPI_README}" \
-                "${__directory}/${PROJECT_PYPI_README}"
+                "${_directory}/${PROJECT_PYPI_README}"
         if [ $? -ne 0 ]; then
                 return 1
         fi
 
 
         # generate the pyproject.toml
-        FS::write_file "${__directory}/pyproject.toml" "\
+        FS::write_file "${_directory}/pyproject.toml" "\
 [build-system]
 requires = [ 'setuptools' ]
 build-backend = 'setuptools.build_meta'

--- a/srcPYTHON/.ci/_package-pypi_windows-any.ps1
+++ b/srcPYTHON/.ci/_package-pypi_windows-any.ps1
@@ -27,16 +27,16 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 
 function PACKAGE-Assemble-PYPI-Content {
 	param (
-		[string]$__target,
-		[string]$__directory,
-		[string]$__target_name,
-		[string]$__target_os,
-		[string]$__target_arch
+		[string]$_target,
+		[string]$_directory,
+		[string]$_target_name,
+		[string]$_target_os,
+		[string]$_target_arch
 	)
 
 
 	# validate project
-	$__process = FS-Is-Target-A-Source "$__target"
+	$__process = FS-Is-Target-A-Source "$_target"
 	if ($__process -ne 0) {
 		return 10
 	}
@@ -48,21 +48,23 @@ function PACKAGE-Assemble-PYPI-Content {
 
 	# assemble the python package
 	PYTHON-Clean-Artifact "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}"
-	$__process = FS-Copy-All "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\Libs" `
-				"${__directory}"
+	$__process = FS-Copy-All `
+				"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\Libs" `
+				"${_directory}"
 	if ($__process -ne 0) {
 		return 1
 	}
 
-	$__process = FS-Copy-File "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYPI_README}" `
-				"${__directory}\${env:PROJECT_PYPI_README}"
+	$__process = FS-Copy-File `
+				"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYPI_README}" `
+				"${_directory}\${env:PROJECT_PYPI_README}"
 	if ($__process -ne 0) {
 		return 1
 	}
 
 
 	# generate the pyproject.toml
-	$__process = FS-Write-File "${__directory}\pyproject.toml" @"
+	$__process = FS-Write-File "${_directory}\pyproject.toml" @"
 [build-system]
 requires = [ 'setuptools' ]
 build-backend = 'setuptools.build_meta'

--- a/srcPYTHON/.ci/build_unix-any.sh
+++ b/srcPYTHON/.ci/build_unix-any.sh
@@ -61,6 +61,15 @@ fi
 
 
 # build output binary file
+case "$PROJECT_OS" in
+windows)
+        __file="${PROJECT_SKU}_${PROJECT_OS}-${PROJECT_ARCH}.exe"
+        ;;
+*)
+        __file="${PROJECT_SKU}_${PROJECT_OS}-${PROJECT_ARCH}"
+        ;;
+esac
+
 __file="${PROJECT_SKU}_${PROJECT_OS}-${PROJECT_ARCH}"
 OS::print_status info "building output file: ${__file}\n"
 pyinstaller --noconfirm \
@@ -82,6 +91,18 @@ fi
 
 # placeholding source code flag
 __file="${PROJECT_SKU}-src_${PROJECT_OS}-${PROJECT_ARCH}"
+OS::print_status info "building output file: ${__file}\n"
+touch "${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}/${__file}"
+if [ $? -ne 0 ]; then
+        OS::print_status error "build failed.\n"
+        return 1
+fi
+
+
+
+
+# placeholding homebrew code flag
+__file="${PROJECT_SKU}-homebrew_any-any"
 OS::print_status info "building output file: ${__file}\n"
 touch "${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}/${__file}"
 if [ $? -ne 0 ]; then

--- a/srcPYTHON/.ci/materialize_windows-any.ps1
+++ b/srcPYTHON/.ci/materialize_windows-any.ps1
@@ -64,19 +64,19 @@ if ($__process -ne 0) {
 # build output binary file
 switch (${env:PROJECT_OS}) {
 windows {
-	$__file = "${env:PROJECT_SKU}_${env:PROJECT_OS}-${env:PROJECT_ARCH}.exe"
+	$__source = "${env:PROJECT_SKU}_${env:PROJECT_OS}-${env:PROJECT_ARCH}.exe"
 } default {
-	$__file = "${env:PROJECT_SKU}_${env:PROJECT_OS}-${env:PROJECT_ARCH}"
+	$__source = "${env:PROJECT_SKU}_${env:PROJECT_OS}-${env:PROJECT_ARCH}"
 }}
 
-OS-Print-Status info "building output file: ${__file}"
+OS-Print-Status info "building output file: ${__source}"
 $__argument = "--noconfirm " `
 	+ "--onefile " `
 	+ "--clean " `
 	+ "--distpath `"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BUILD}`" " `
 	+ "--workpath `"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TEMP}`" " `
 	+ "--specpath `"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_LOG}`" " `
-	+ "--name `"${__file}`" " `
+	+ "--name `"${__source}`" " `
 	+ "--hidden-import=main " `
 	+ "`"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\main.py`""
 $__process = OS-Exec "pyinstaller" "${__argument}"
@@ -88,40 +88,15 @@ if ($__process -ne 0) {
 
 
 
-# placeholding source code flag
-$__file = "${env:PROJECT_SKU}-src_${env:PROJECT_OS}-${env:PROJECT_ARCH}"
-OS-Print-Status info "building output file: ${__file}"
-$__process = FS-Touch-File "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BUILD}\${__file}"
+# exporting executable
+$__source = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BUILD}\${__source}"
+$__dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BIN}\${env:PROJECT_SKU}.exe"
+OS-Print-Status info "exporting ${__source} to ${__dest}"
+$null = FS-Make-Directory "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BIN}"
+$null = FS-Remove-Silently "${__dest}"
+$__process = FS-Move "${__source}" "${__dest}"
 if ($__process -ne 0) {
-	OS-Print-Status error "build failed."
-	return 1
-}
-
-
-
-
-# placeholding homebrew flag
-$__file = "${env:PROJECT_SKU}-homebrew_any-any"
-OS-Print-Status info "building output file: ${__file}"
-$__process = FS-Touch-File "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BUILD}\${__file}"
-if ($__process -ne 0) {
-	OS-Print-Status error "build failed."
-	return 1
-}
-
-
-
-
-# compose documentations
-OS-Print-Status info "printing html documentations..."
-$__output = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_DOCS}\python"
-FS-Remake-Directory "${__output}\${env:PROJECT_OS}-${env:PROJECT_ARCH}"
-$__arguments = "--html " +
-		"--output-dir `"${__output}\${env:PROJECT_OS}-${env:PROJECT_ARCH}`" " +
-		"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\Libs\"
-$__process = OS-Exec "pdoc" "${__arguments}"
-if ($__process -ne 0) {
-	OS-Print-Status error "build failed."
+	OS-Print-Status error "export failed."
 	return 1
 }
 

--- a/srcPYTHON/.ci/package_unix-any.sh
+++ b/srcPYTHON/.ci/package_unix-any.sh
@@ -21,8 +21,9 @@ if [ "$PROJECT_PATH_ROOT" == "" ]; then
 fi
 
 . "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/${PROJECT_PATH_CI}/_package-archive_unix-any.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/${PROJECT_PATH_CI}/_package-pypi_unix-any.sh"
 . "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/${PROJECT_PATH_CI}/_package-docker_unix-any.sh"
+. "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/${PROJECT_PATH_CI}/_package-homebrew_unix-any.sh"
+. "${PROJECT_PATH_ROOT}/${PROJECT_PYTHON}/${PROJECT_PATH_CI}/_package-pypi_unix-any.sh"
 
 
 

--- a/srcPYTHON/.ci/package_windows-any.ps1
+++ b/srcPYTHON/.ci/package_windows-any.ps1
@@ -20,8 +20,9 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 }
 
 . "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\${env:PROJECT_PATH_CI}\_package-archive_windows-any.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\${env:PROJECT_PATH_CI}\_package-pypi_windows-any.ps1"
 . "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\${env:PROJECT_PATH_CI}\_package-docker_windows-any.ps1"
+. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\${env:PROJECT_PATH_CI}\_package-homebrew_windows-any.ps1"
+. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PYTHON}\${env:PROJECT_PATH_CI}\_package-pypi_windows-any.ps1"
 
 
 


### PR DESCRIPTION
Now that the Homebrew ecosystem is now ready, we should backport it to the Python programming language. Hence, let's do this.

This patch enables Homebrew for Python programming langauge in srcPYTHON/ directory.