### PR TITLE
root: applied regressive changes back to Go programming language

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -126,7 +126,7 @@ PROJECT_PATH_NIM_ENGINE = "nim-engine"
 #
 # To enable it: simply supply the path (e.g. default is 'srcC').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_C = 'srcC'
+PROJECT_C = ''
 
 
 
@@ -142,7 +142,7 @@ PROJECT_C = 'srcC'
 #
 # To enable it: simply supply the path (e.g. default is 'srcGO').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_GO = ''
+PROJECT_GO = 'srcGO'
 
 
 # PROJECT_PATH_GO_ENGINE

--- a/src/changelog/data/latest
+++ b/src/changelog/data/latest
@@ -1,1 +1,2 @@
+root: applied regressive changes to C programming language
 root: added Nim Programming Language support

--- a/src/changelog/deb/latest
+++ b/src/changelog/deb/latest
@@ -1,5 +1,6 @@
 automataci (1.7.0) stable; urgency=low
 
+  * root: applied regressive changes to C programming language
   * root: added Nim Programming Language support
 
--- Your Legal Full Name Here <contact@youremail.example>  Mon, 16 Oct 2023 13:05:06 +0800
+-- Your Legal Full Name Here <contact@youremail.example>  Mon, 16 Oct 2023 14:42:32 +0800


### PR DESCRIPTION
Since Nim programming language introduces a lot of infra changes, we should apply them regressively back to Go. Hence, let's do this.

This patch applies regressive changes back to Go programming language in root repository.