### PR TITLE
automataCI: added i18n feature to rpm packager function

### DIFF
--- a/automataCI/_package-msi_unix-any.sh
+++ b/automataCI/_package-msi_unix-any.sh
@@ -14,8 +14,8 @@
 . "${LIBS_AUTOMATACI}/services/compilers/msi.sh"
 
 . "${LIBS_AUTOMATACI}/services/i18n/printer.sh"
-. "${LIBS_AUTOMATACI}/services/i18n/status-msi.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/status-job-package.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/status-run.sh"
 
 
 
@@ -104,10 +104,10 @@ PACKAGE_Run_MSI() {
 
 
         # validate input
-        I18N_Status_Print_MSI_Check_Availability
+        I18N_Status_Print_Check_Availability "MSI"
         MSI_Is_Available
         if [ $? -ne 0 ]; then
-                I18N_Status_Print_MSI_Check_Availability_Failed
+                I18N_Status_Print_Check_Availability_Failed "MSI"
                 return 0
         fi
 

--- a/automataCI/_package-msi_windows-any.ps1
+++ b/automataCI/_package-msi_windows-any.ps1
@@ -16,7 +16,7 @@
 
 . "${env:LIBS_AUTOMATACI}\services\i18n\printer.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\status-job-package.ps1"
-. "${env:LIBS_AUTOMATACI}\services\i18n\status-msi.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-run.ps1"
 
 
 

--- a/automataCI/_package-rpm_unix-any.sh
+++ b/automataCI/_package-rpm_unix-any.sh
@@ -10,11 +10,14 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/copyright.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/manual.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/rpm.sh"
+. "${LIBS_AUTOMATACI}/services/io/os.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/compilers/copyright.sh"
+. "${LIBS_AUTOMATACI}/services/compilers/manual.sh"
+. "${LIBS_AUTOMATACI}/services/compilers/rpm.sh"
+
+. "${LIBS_AUTOMATACI}/services/i18n/status-job-package.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/status-run.sh"
 
 
 
@@ -33,59 +36,60 @@ PACKAGE::run_rpm() {
 
 
         # parse input
-        __line="${1%|*}"
+        __line="$1"
+
+        _dest="${__line%%|*}"
+        __line="${__line#*|}"
+
+        _target="${__line%%|*}"
+        __line="${__line#*|}"
+
+        _target_filename="${__line%%|*}"
+        __line="${__line#*|}"
+
+        _target_os="${__line%%|*}"
+        __line="${__line#*|}"
+
+        _target_arch="${__line%%|*}"
+        __line="${__line#*|}"
 
         _target_arch="${__line##*|}"
         __line="${__line%|*}"
 
-        _target_os="${__line##*|}"
-        __line="${__line%|*}"
-
-        _target_filename="${__line##*|}"
-        __line="${__line%|*}"
-
-        _target="${__line##*|}"
-        __line="${__line%|*}"
-
-        _dest="${__line##*|}"
-
 
         # validate input
-        OS::print_status info "checking rpm functions availability...\n"
+        I18N_Status_Print_Check_Availability "RPM"
         RPM::is_available "$_target_os" "$_target_arch"
         case $? in
-        2)
-                OS::print_status warning "RPM is incompatible (OS type). Skipping.\n"
-                return 0
-                ;;
-        3)
-                OS::print_status warning "RPM is incompatible (CPU type). Skipping.\n"
+        2|3)
+                I18N_Status_Print_Check_Availability_Incompatible "RPM"
                 return 0
                 ;;
         0)
+                # accepted
                 ;;
         *)
-                OS::print_status warning "RPM is unavailable. Skipping.\n"
+                I18N_Status_Print_Check_Availability_Failed "RPM"
                 return 0
                 ;;
         esac
 
-        OS::print_status info "checking manual docs functions availability...\n"
+        I18N_Status_Print_Check_Availability "MANUAL DOCS"
         MANUAL::is_available
         if [ $? -ne 0 ]; then
-                OS::print_status error "checking failed.\n"
+                I18N_Status_Print_Check_Availability_Failed "MANUAL DOCS"
                 return 1
         fi
 
 
         # prepare workspace and required values
+        I18N_Status_Print_Package_Create "RPM"
         _src="${_target_filename}_${_target_os}-${_target_arch}"
         _src="${PROJECT_PATH_ROOT}/${PROJECT_PATH_TEMP}/rpm_${_src}"
-        OS::print_status info "Creating RPM package...\n"
-        OS::print_status info "remaking workspace directory ${_src}\n"
+        I18N_Status_Print_Package_Workspace_Remake "$_src"
         FS::remake_directory "$_src"
         if [ $? -ne 0 ]; then
-                OS::print_status error "remake failed.\n"
+                I18N_Status_Print_Package_Remake_Failed
                 return 1
         fi
         FS::make_directory "${_src}/BUILD"
@@ -93,37 +97,36 @@ PACKAGE::run_rpm() {
 
 
         # copy all complimentary files to the workspace
-        OS::print_status info "assembling package files...\n"
-        if [ -z "$(type -t PACKAGE::assemble_rpm_content)" ]; then
-                OS::print_status error "missing PACKAGE::assemble_rpm_content function.\n"
+        cmd="PACKAGE::assemble_rpm_content"
+        I18N_Status_Print_Package_Assembler_Check "$cmd"
+        OS::is_command_available "$cmd"
+        if [ $? -ne 0 ]; then
+                I18N_Status_Print_Package_Check_Failed
                 return 1
         fi
-        PACKAGE::assemble_rpm_content \
-                "$_target" \
-                "$_src" \
-                "$_target_filename" \
-                "$_target_os" \
-                "$_target_arch"
+
+        "$cmd" "$_target" "$_src" "$_target_filename" "$_target_os" "$_target_arch"
         case $? in
         10)
+                I18N_Status_Print_Package_Assembler_Exec_Skipped
                 FS::remove_silently "$_src"
-                OS::print_status warning "packaging is not required. Skipping process.\n"
                 return 0
                 ;;
         0)
+                # accepted
                 ;;
         *)
-                OS::print_status error "assembly failed.\n"
+                I18N_Status_Print_Package_Assembler_Exec_Failed
                 return 1
                 ;;
         esac
 
 
         # archive the assembled payload
-        OS::print_status info "archiving .rpm package...\n"
+        I18N_Status_Print_Package_Exec "$_dest"
         RPM::create_archive "$_src" "$_dest" "$_target_arch"
         if [ $? -ne 0 ]; then
-                OS::print_status error "package failed.\n"
+                I18N_Status_Print_Package_Exec_Failed "$_dest"
                 return 1
         fi
 

--- a/automataCI/_package-sourcing_unix-any.sh
+++ b/automataCI/_package-sourcing_unix-any.sh
@@ -13,7 +13,7 @@
 . "${LIBS_AUTOMATACI}/services/io/fs.sh"
 . "${LIBS_AUTOMATACI}/services/io/strings.sh"
 
-. "${LIBS_AUTOMATACI}/services/i18n/_status-job-package-source.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/status-job-package.sh"
 
 
 

--- a/automataCI/_package-sourcing_windows-any.ps1
+++ b/automataCI/_package-sourcing_windows-any.ps1
@@ -12,7 +12,7 @@
 . "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
 . "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
 
-. "${env:LIBS_AUTOMATACI}\services\i18n\_status-job-package-source.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-job-package.ps1"
 
 
 

--- a/automataCI/services/i18n/_status-job-package-source.sh
+++ b/automataCI/services/i18n/_status-job-package-source.sh
@@ -1,4 +1,4 @@
-18N_Status_Print_Package_Source# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/automataCI/services/i18n/_status-run-check-availability.ps1
+++ b/automataCI/services/i18n/_status-run-check-availability.ps1
@@ -14,12 +14,18 @@
 
 
 
-function I18N-Status-Print-MSI-Check-Availability {
+function I18N-Status-Print-Check-Availability {
+	param(
+		[string]$___subject
+	)
+
+
 	# execute
 	switch (${env:AUTOMATACI_LANG}) {
 	default {
 		# fallback to default english
-		$null = I18N-Status-Print info "checking MSI functions availability...`n"
+		$null = I18N-Status-Print info `
+			"checking ${___subject} functions availability...`n"
 	}}
 
 
@@ -30,12 +36,38 @@ function I18N-Status-Print-MSI-Check-Availability {
 
 
 
-function I18N-Status-Print-MSI-Check-Availability-Failed {
+function I18N-Status-Print-Check-Availability-Failed {
+	param(
+		[string]$___subject
+	)
+
+
 	# execute
 	switch (${env:AUTOMATACI_LANG}) {
 	default {
 		# fallback to default english
-		$null = I18N-Status-Print warning "MSI is unavailable. Skipping...`n"
+		$null = I18N-Status-Print info "${___subject} is unavailable. Skipping...`n"
+	}}
+
+
+	# report status
+	return 0
+}
+
+
+
+
+function I18N-Status-Print-Check-Availability-Incompatible {
+	param(
+		[string]$___subject
+	)
+
+
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$null = I18N-Status-Print info "${___subject} is incompatible. Skipping...`n"
 	}}
 
 

--- a/automataCI/services/i18n/_status-run-check-availability.sh
+++ b/automataCI/services/i18n/_status-run-check-availability.sh
@@ -14,12 +14,16 @@
 
 
 
-I18N_Status_Print_MSI_Check_Availability() {
+I18N_Status_Print_Check_Availability() {
+        ___subject="$1"
+
+
         # execute
         case "$AUTOMATACI_LANG" in
         *)
                 # fallback to default english
-                I18N_Status_Print info "checking MSI functions availability...\n"
+                ___subject="$(I18N_Status_Param_Process "${___subject}")"
+                I18N_Status_Print info "checking ${___subject} functions availability...\n"
                 ;;
         esac
 
@@ -31,12 +35,37 @@ I18N_Status_Print_MSI_Check_Availability() {
 
 
 
-I18N_Status_Print_MSI_Check_Availability_Failed() {
+I18N_Status_Print_Check_Availability_Failed() {
+        ___subject="$1"
+
+
         # execute
         case "$AUTOMATACI_LANG" in
         *)
                 # fallback to default english
-                I18N_Status_Print warning "MSI is unavailable. Skipping...\n"
+                ___subject="$(I18N_Status_Param_Process "${___subject}")"
+                I18N_Status_Print warning "${___subject} is unavailable. Skipping...\n\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}
+
+
+
+
+I18N_Status_Print_Check_Availability_Incompatible() {
+        ___subject="$1"
+
+
+        # execute
+        case "$AUTOMATACI_LANG" in
+        *)
+                # fallback to default english
+                ___subject="$(I18N_Status_Param_Process "${___subject}")"
+                I18N_Status_Print warning "${___subject} is incompatible. Skipping...\n\n"
                 ;;
         esac
 

--- a/automataCI/services/i18n/status-job-package.ps1
+++ b/automataCI/services/i18n/status-job-package.ps1
@@ -15,6 +15,7 @@
 . "${env:LIBS_AUTOMATACI}\services\i18n\_status-job-package-export.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\_status-job-package-parallelism.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\_status-job-package-remake.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\_status-job-package-source.ps1"
 
 
 

--- a/automataCI/services/i18n/status-job-package.sh
+++ b/automataCI/services/i18n/status-job-package.sh
@@ -15,6 +15,7 @@
 . "${LIBS_AUTOMATACI}/services/i18n/_status-job-package-export.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/_status-job-package-parallelism.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/_status-job-package-remake.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/_status-job-package-source.sh"
 
 
 

--- a/automataCI/services/i18n/status-run.ps1
+++ b/automataCI/services/i18n/status-run.ps1
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 . "${env:LIBS_AUTOMATACI}\services\i18n\printer.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\_status-run-check-availability.ps1"
 
 
 

--- a/automataCI/services/i18n/status-run.sh
+++ b/automataCI/services/i18n/status-run.sh
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 . "${LIBS_AUTOMATACI}/services/i18n/printer.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/_status-run-check-availability.sh"
 
 
 


### PR DESCRIPTION
Since we want to support i18n entirely, we should add i18n feature to the rpm packager function. Hence, let's do this.

This patch adds i18n feature to rpm packager function in automataCI/ directory.