### PR TITLE
automataCI: added i18n feature to homebrew packaging function

### DIFF
--- a/automataCI/_package-homebrew_windows-any.ps1
+++ b/automataCI/_package-homebrew_windows-any.ps1
@@ -9,18 +9,23 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\os.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\strings.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\archive\tar.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\checksum\shasum.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\os.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
+. "${env:LIBS_AUTOMATACI}\services\archive\tar.ps1"
+. "${env:LIBS_AUTOMATACI}\services\checksum\shasum.ps1"
+
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-file.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-job-package.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-run.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-shasum.ps1"
 
 
 
 
 # initialize
 if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
-	Write-Error "[ ERROR ] - Please run from ci.cmd instead!\n"
+	Write-Error "[ ERROR ] - Please run from ci.cmd instead!`n"
 	return
 }
 
@@ -43,36 +48,46 @@ function PACKAGE-Run-Homebrew {
 
 
 	# validate input
-	OS-Print-Status info "checking tar functions availability..."
+	$null = I18N-Status-Print-Check-Availability "TAR"
 	$__process = TAR-Is-Available
 	if ($__process -ne 0) {
-		OS-Print-Status error "checking failed."
+		$null = I18N-Status-Print-Check-Availability-Incompatible "TAR"
 		return 1
 	}
 
 
 	# prepare workspace and required values
+	$null = I18N-Status-Print-Package-Create "HOMEBREW"
 	$_src = "${_target_filename}_${env:PROJECT_VERSION}_${_target_os}-${_target_arch}"
 	$_target_path = "${_dest}\${_src}"
 	$_src = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_TEMP}\homebrew_${_src}"
-	OS-Print-Status info "creating homebrew source package..."
-	OS-Print-Status info "remaking workspace directory ${_src}"
+	$null = I18N-Status-Print-Package-Workspace-Remake "${_src}"
 	$__process = FS-Remake-Directory "${_src}"
 	if ($__process -ne 0) {
-		OS-Print-Status error "remake failed."
+		$null = I18N-Status-Print-Package-Remake-Failed
+		return 1
+	}
+
+
+	# check formula.rb is available
+	$null = I18N-Status-Print-File-Check-Exists "formula.rb"
+	$__process = FS-Is-File "${_src}/formula.rb"
+	if ($__process -eq 0) {
+		$null = I18N-Status-Print-File-Check-Failed
 		return 1
 	}
 
 
 	# copy all complimentary files to the workspace
-	OS-Print-Status info "checking PACKAGE-Assemble-HOMEBREW-Content function..."
-	$__process = OS-Is-Command-Available "PACKAGE-Assemble-HOMEBREW-Content"
+	$cmd = "PACKAGE-Assemble-HOMEBREW-Content"
+	$null = I18N-Status-Print-Package-Assembler-Check "$cmd"
+	$__process = OS-Is-Command-Available "$cmd"
 	if ($__process -ne 0) {
-		OS-Print-Status error "missing PACKAGE-Assemble-HOMEBREW-Content function."
+		$null = I18N-Status-Print-Package-Check-Failed
 		return 1
 	}
 
-	OS-Print-Status info "assembling package files..."
+	$null = I18N-Status-Print-Package-Assembler-Exec
 	$__process = PACKAGE-Assemble-HOMEBREW-Content `
 		"${_target}" `
 		"${_src}" `
@@ -81,50 +96,41 @@ function PACKAGE-Run-Homebrew {
 		"${_target_arch}"
 	switch ($__process) {
 	10 {
+		$null = I18N-Status-Print-Package-Assembler-Exec-Skipped
 		$null = FS-Remove-Silently "${_src}"
-		OS-Print-Status warning "packaging is not required. Skipping process."
 		return 0
 	} 0 {
 		# accepted
 	} Default {
-		OS-Print-Status error "assembly failed."
+		$null = I18N-Status-Print-Package-Assembler-Exec-Failed
 		return 1
 	}}
-
-
-	# check formula.rb is available
-	OS-Print-Status info "checking formula.rb availability..."
-	$__process = FS-Is-File "${_src}/formula.rb"
-	if ($__process -ne 0) {
-		OS-Print-Status error "check failed."
-		return 1
-	}
 
 
 	# archive the assembled payload
 	$__current_path = Get-Location
 	$null = Set-Location -Path "${_src}"
-	OS-Print-Status info "archiving ${_target_path}.tar.xz"
+	$null = I18N-Status-Print-File-Archive "${_target_path}.tar.xz"
 	$__process = TAR-Create-XZ "${_target_path}.tar.xz" "*"
 	$null = Set-Location -Path "${__current_path}"
 	$null = Remove-Variable -Name __current_path
 	if ($__process -ne 0) {
-		OS-Print-Status error "archive failed."
+		$null = I18N-Status-Print-File-Archive-Failed
 		return 1
 	}
 
 
 	# sha256 the package
-	OS-Print-Status info "shasum the package with sha256 algorithm..."
+	$null = I18N-Status-Print-Shasum "SHA256"
 	$__shasum = SHASUM-Checksum-File "${_target_path}.tar.xz" "256"
-	if ([string]::IsNullOrEmpty($__shasum)) {
-		OS-Print-Status error "shasum failed."
+	if ($(STRINGS-Is-Empty "${__shasum}") -eq 0) {
+		$null = I18N-Status-Print-Shasum-Failed
 		return 1
 	}
 
 
 	# update the formula.rb script
-	OS-Print-Status info "update given formula.rb file..."
+	$null = I18N-Status-Print-File-Update "formula.rb"
 	$null = FS-Remove-Silently "${_target_path}.rb"
 	foreach ($__line in (Get-Content "${_src}\formula.rb")) {
 		$__line = STRINGS-Replace-All `
@@ -139,6 +145,7 @@ function PACKAGE-Run-Homebrew {
 
 		$__process = FS-Append-File "${_target_path}.rb" "${__line}"
 		if ($__process -ne 0) {
+			$null = I18N-Status-Print-File-Update-Failed
 			return 1
 		}
 	}

--- a/automataCI/services/i18n/_status-file-archive.ps1
+++ b/automataCI/services/i18n/_status-file-archive.ps1
@@ -1,0 +1,50 @@
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${env:LIBS_AUTOMATACI}\services\i18n\printer.ps1"
+
+
+
+
+function I18N-Status-Print-File-Archive {
+	param(
+		[string]$___subject
+	)
+
+
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$___subject = I18N-Status-Param-Process "${___subject}"
+		$null = I18N-Status-Print info "archiving ${___subject}`n"
+	}}
+
+
+	# report status
+	return 0
+}
+
+
+
+
+function I18N-Status-Print-File-Archive-Failed {
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$null = I18N-Status-Print error "archive failed.`n`n"
+	}}
+
+
+	# report status
+	return 0
+}

--- a/automataCI/services/i18n/_status-file-archive.sh
+++ b/automataCI/services/i18n/_status-file-archive.sh
@@ -1,0 +1,50 @@
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${LIBS_AUTOMATACI}/services/i18n/printer.sh"
+
+
+
+
+I18N_Status_Print_File_Archive() {
+        ___subject="$1"
+
+
+        # execute
+        case "$AUTOMATACI_LANG" in
+        *)
+                # fallback to default english
+                ___subject="$(I18N_Status_Param_Process "${___subject}")"
+                I18N_Status_Print info "archiving ${___subject}\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}
+
+
+
+
+I18N_Status_Print_File_Archive_Failed() {
+        # execute
+        case "$AUTOMATACI_LANG" in
+        *)
+                # fallback to default english
+                I18N_Status_Print error "archive failed.\n\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}

--- a/automataCI/services/i18n/_status-file-update.ps1
+++ b/automataCI/services/i18n/_status-file-update.ps1
@@ -1,0 +1,50 @@
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${env:LIBS_AUTOMATACI}\services\i18n\printer.ps1"
+
+
+
+
+function I18N-Status-Print-File-Update {
+	param(
+		[string]$___subject
+	)
+
+
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$___subject = I18N-Status-Param-Process "${___subject}"
+		$null = I18N-Status-Print info "updating ${___subject}`n"
+	}}
+
+
+	# report status
+	return 0
+}
+
+
+
+
+function I18N-Status-Print-File-Update-Failed {
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$null = I18N-Status-Print error "updated failed.`n`n"
+	}}
+
+
+	# report status
+	return 0
+}

--- a/automataCI/services/i18n/_status-file-update.sh
+++ b/automataCI/services/i18n/_status-file-update.sh
@@ -1,0 +1,50 @@
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${LIBS_AUTOMATACI}/services/i18n/printer.sh"
+
+
+
+
+I18N_Status_Print_File_Update() {
+        ___subject="$1"
+
+
+        # execute
+        case "$AUTOMATACI_LANG" in
+        *)
+                # fallback to default english
+                ___subject="$(I18N_Status_Param_Process "${___subject}")"
+                I18N_Status_Print info "updating ${___subject}\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}
+
+
+
+
+I18N_Status_Print_File_Update_Failed() {
+        # execute
+        case "$AUTOMATACI_LANG" in
+        *)
+                # fallback to default english
+                I18N_Status_Print error "update failed.\n\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}

--- a/automataCI/services/i18n/status-file.ps1
+++ b/automataCI/services/i18n/status-file.ps1
@@ -11,8 +11,10 @@
 # under the License.
 . "${env:LIBS_AUTOMATACI}\services\i18n\printer.ps1"
 
+. "${env:LIBS_AUTOMATACI}\services\i18n\_status-file-archive.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\_status-file-check.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\_status-file-create.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\_status-file-update.ps1"
 
 
 
@@ -76,6 +78,23 @@ function I18N-Status-Print-File-Incompatible-Skipped {
 	# report status
 	return 0
 }
+
+
+
+
+function I18N-Status-Print-File-Injected {
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$null = I18N-Status-Print warning "manual injection detected.`n"
+	}}
+
+
+	# report status
+	return 0
+}
+
 
 
 

--- a/automataCI/services/i18n/status-file.sh
+++ b/automataCI/services/i18n/status-file.sh
@@ -11,8 +11,10 @@
 # under the License.
 . "${LIBS_AUTOMATACI}/services/i18n/printer.sh"
 
+. "${LIBS_AUTOMATACI}/services/i18n/_status-file-archive.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/_status-file-check.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/_status-file-create.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/_status-file-update.sh"
 
 
 

--- a/automataCI/services/i18n/status-shasum.ps1
+++ b/automataCI/services/i18n/status-shasum.ps1
@@ -1,0 +1,51 @@
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${env:LIBS_AUTOMATACI}\services\i18n\printer.ps1"
+
+
+
+
+function I18N-Status-Print-Shasum {
+	param(
+		[string]$___subject
+	)
+
+
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$___subject = I18N-Status-Param-Process "${___subject}"
+		$null = I18N-Status-Print info `
+				"shasum the package with ${___subject} algorithm...`n"
+	}}
+
+
+	# report status
+	return 0
+}
+
+
+
+
+function I18N-Status-Print-Shasum-Failed {
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$null = I18N-Status-Print error "shasum failed.`n`n"
+	}}
+
+
+	# report status
+	return 0
+}

--- a/automataCI/services/i18n/status-shasum.sh
+++ b/automataCI/services/i18n/status-shasum.sh
@@ -1,0 +1,50 @@
+# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${LIBS_AUTOMATACI}/services/i18n/printer.sh"
+
+
+
+
+I18N_Status_Print_Shasum() {
+        ___subject="$1"
+
+
+        # execute
+        case "$AUTOMATACI_LANG" in
+        *)
+                # fallback to default english
+                ___subject="$(I18N_Status_Param_Process "${___subject}")"
+                I18N_Status_Print info "shasum the package with ${___subject} algorithm...\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}
+
+
+
+
+I18N_Status_Print_Shasum_Failed() {
+        # execute
+        case "$AUTOMATACI_LANG" in
+        *)
+                # fallback to default english
+                I18N_Status_Print error "shasum failed.\n\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}


### PR DESCRIPTION
Since we want i18n feature to be applied across all package CI job, we should first deal with homebrew packaging function. Hence, let's do this.

This patch applies i18n feature to homebrew packaging function in automataCI/ directory.