### PR TITLE
automataCI: added i18n for archive packaging function

### DIFF
--- a/automataCI/package_unix-any.sh
+++ b/automataCI/package_unix-any.sh
@@ -167,7 +167,7 @@ for i in "${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}"/*; do
 
         __log="${__log_directory}/archive_${TARGET_FILENAME}_${TARGET_OS}-${TARGET_ARCH}.log"
         FS::append_file "$__parallel_control" "\
-${__common}|${__log}|PACKAGE::run_archive
+${__common}|${__log}|PACKAGE_Run_ARCHIVE
 "
         if [ $? -ne 0 ]; then
                 return 1

--- a/automataCI/package_windows-any.ps1
+++ b/automataCI/package_windows-any.ps1
@@ -183,7 +183,7 @@ foreach ($file in (Get-ChildItem -Path "${env:PROJECT_PATH_ROOT}\${env:PROJECT_P
 
 	$__log = "${__log_directory}\archive_${TARGET_FILENAME}_${TARGET_OS}-${TARGET_ARCH}.log"
 	$__process = FS-Append-File "${__parallel_control}" @"
-${__common}|${__log}|PACKAGE-Run-Archive
+${__common}|${__log}|PACKAGE-Run-ARCHIVE
 "@
 	if ($__process -ne 0) {
 		return 1

--- a/src/.ci/_package-archive_unix-any.sh
+++ b/src/.ci/_package-archive_unix-any.sh
@@ -26,7 +26,7 @@ fi
 
 
 
-PACKAGE::assemble_archive_content() {
+PACKAGE_Assemble_ARCHIVE_Content() {
         _target="$1"
         _directory="$2"
         _target_name="$3"

--- a/src/.ci/_package-archive_windows-any.ps1
+++ b/src/.ci/_package-archive_windows-any.ps1
@@ -25,7 +25,7 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 
 
 
-function PACKAGE-Assemble-Archive-Content {
+function PACKAGE-Assemble-ARCHIVE-Content {
 	param(
 		[string]$_target,
 		[string]$_directory,

--- a/srcRUST/.ci/_package-archive_unix-any.sh
+++ b/srcRUST/.ci/_package-archive_unix-any.sh
@@ -27,7 +27,7 @@ fi
 
 
 
-PACKAGE::assemble_archive_content() {
+PACKAGE_Assemble_ARCHIVE_Content() {
         _target="$1"
         _directory="$2"
         _target_name="$3"

--- a/srcRUST/.ci/_package-archive_windows-any.ps1
+++ b/srcRUST/.ci/_package-archive_windows-any.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 
 
 
-function PACKAGE-Assemble-Archive-Content {
+function PACKAGE-Assemble-ARCHIVE-Content {
 	param(
 		[string]$_target,
 		[string]$_directory,


### PR DESCRIPTION
Since we want i18n feature to be applied across all package CI job, we should first deal with archive packaging function. Hence, let's do this.

This patch applies i18n feature to archive packaging function in automataCI/ directory.