### PR TITLE
automataCI: added i18n feature to release cargo function

### DIFF
--- a/automataCI/release_unix-any.sh
+++ b/automataCI/release_unix-any.sh
@@ -115,7 +115,7 @@ for TARGET in "${PROJECT_PATH_ROOT}/${PROJECT_PATH_PKG}"/*; do
                 return 1
         fi
 
-        RELEASE::run_cargo "$TARGET"
+        RELEASE_Run_CARGO "$TARGET"
         if [ $? -ne 0 ]; then
                 return 1
         fi

--- a/automataCI/services/compilers/rust.sh
+++ b/automataCI/services/compilers/rust.sh
@@ -10,9 +10,9 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/strings.sh"
+. "${LIBS_AUTOMATACI}/services/io/os.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/strings.sh"
 
 
 


### PR DESCRIPTION
Since we want i18n feature to be applied across all release CI job, we should first deal with release cargo function. Hence, let's do this.

Thi spatch applies i18n feature to release cargo function in automataCI/ directory.