### PR TITLE
automataCI: added i18n feature to release changelog function

### DIFF
--- a/automataCI/_release-changelog_unix-any.sh
+++ b/automataCI/_release-changelog_unix-any.sh
@@ -10,21 +10,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/changelog.sh"
+. "${LIBS_ATUOMATACI}/services/compilers/changelog.sh"
+
+. "${LIBS_ATUOMATACI}/services/i18n/status-file.sh"
 
 
 
 
-RELEASE::run_changelog_conclude() {
+RELEASE_Conclude_CHANGELOG() {
         # execute
-        OS::print_status info "sealing changelog latest entries...\n"
+        I18N_Status_Print_File_Export "${PROJECT_VERSION} CHANGELOG"
         CHANGELOG_Seal \
-                "${PROJECT_PATH_ROOT}/${PROJECT_PATH_RESOURCES}/changelog" \
+                "${PROJECT_PATH_ROOT}/${PROJECT_PATH_SOURCE}/changelog" \
                 "$PROJECT_VERSION"
         if [ $? -ne 0 ]; then
-                OS::print_status error "seal failed.\n"
+                I18N_Status_Print_File_Export_Failed
                 return 1
         fi
 

--- a/automataCI/_release-changelog_windows-any.ps1
+++ b/automataCI/_release-changelog_windows-any.ps1
@@ -9,20 +9,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\os.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\compilers\changelog.ps1"
+. "${env:LIBS_AUTOMATACI}\services\compilers\changelog.ps1"
+
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-file.ps1"
 
 
 
 
-function RELEASE-Run-Changelog-Conclude {
+function RELEASE-Conclude-CHANGELOG {
 	# execute
-	OS-Print-Status info "Sealing changelog latest entries..."
-	$__process = CHANGELOG-Seal `
-		"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\changelog" `
+	$null = I18N-Status-Print-File-Export "${env:PROJECT_VERSION} CHANGELOG"
+	$___process = CHANGELOG-Seal `
+		"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_SOURCE}\changelog" `
 		"${env:PROJECT_VERSION}"
-	if ($__process -ne 0) {
+	if ($___process -ne 0) {
+		$null = I18N-Status-Print-File-Export-Failed
 		return 1
 	}
 

--- a/automataCI/release_unix-any.sh
+++ b/automataCI/release_unix-any.sh
@@ -179,7 +179,7 @@ else
                 return 1
         fi
 
-        RELEASE::run_changelog_conclude
+        RELEASE_Conclude_CHANGELOG
         if [ $? -ne 0 ]; then
                 return 1
         fi

--- a/automataCI/release_windows-any.ps1
+++ b/automataCI/release_windows-any.ps1
@@ -183,8 +183,8 @@ if (-not ([string]::IsNullOrEmpty(${env:PROJECT_SIMULATE_RELEASE_REPO}))) {
 		return 1
 	}
 
-	$__process = RELEASE-Run-Changelog-Conclude
-	if ($__process -ne 0) {
+	$___process = RELEASE-Conclude-CHANGELOG
+	if ($___process -ne 0) {
 		return 1
 	}
 


### PR DESCRIPTION
Since we want i18n feature to be applied across all release CI job, we should first deal with release changelog function. Hence, let's do this.

This patch applies i18n feature to release changelog function in automataCI/ directory.