### PR TITLE
automataCI: fixed MD5_Is_Available bug

### DIFF
--- a/automataCI/services/checksum/md5.sh
+++ b/automataCI/services/checksum/md5.sh
@@ -64,13 +64,13 @@ MD5_Checksum_From_File() {
 MD5_Is_Available() {
         # execute
         OS::is_command_available "md5sum"
-        if [ $? -ne 0 ]; then
-                return 1
+        if [ $? -eq 0 ]; then
+                return 0
         fi
 
         OS::is_command_available "md5"
-        if [ $? -ne 0 ]; then
-                return 1
+        if [ $? -eq 0 ]; then
+                return 0
         fi
 
 


### PR DESCRIPTION
There is a bug in MD5_Is_Available where it will always return negative case. Hence, let's fix it.

This patch fixes MD5_Is_Available bug in automataCI/ directory.