### PR TITLE
automataCI: backported reprepro changes

### DIFF
--- a/automataCI/env_unix-any.sh
+++ b/automataCI/env_unix-any.sh
@@ -26,6 +26,7 @@ fi
 . "${LIBS_AUTOMATACI}/services/compilers/msi.sh"
 . "${LIBS_AUTOMATACI}/services/publishers/dotnet.sh"
 . "${LIBS_AUTOMATACI}/services/publishers/homebrew.sh"
+. "${LIBS_AUTOMATACI}/services/publishers/reprepro.sh"
 
 . "${LIBS_AUTOMATACI}/services/i18n/status-job-env.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/status-run.sh"
@@ -67,7 +68,7 @@ fi
 
 
 I18N_Status_Print_Env_Install "reprepro"
-INSTALLER::setup_reprepro
+REPREPRO_Setup
 if [ $? -ne 0 ]; then
         I18N_Status_Print_Env_Install_Failed
         return 1

--- a/automataCI/env_windows-any.ps1
+++ b/automataCI/env_windows-any.ps1
@@ -24,6 +24,7 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 . "${env:LIBS_AUTOMATACI}\services\compilers\msi.ps1"
 . "${env:LIBS_AUTOMATACI}\services\publishers\chocolatey.ps1"
 . "${env:LIBS_AUTOMATACI}\services\publishers\dotnet.ps1"
+. "${env:LIBS_AUTOMATACI}\services\publishers\reprepro.ps1"
 
 . "${env:LIBS_AUTOMATACI}\services\i18n\status-job-env.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\status-run.ps1"
@@ -65,8 +66,8 @@ if ($__process -ne 0) {
 
 
 $null = I18N-Status-Print-Env-Install "reprepro"
-$__process = INSTALLER-Setup-Reprepro
-if ($__process -ne 0) {
+$___process = REPREPRO-Setup
+if ($___process -ne 0) {
 	$null = I18N-Status-Print-Env-Install-Failed
 	return 1
 }

--- a/automataCI/services/compilers/installer.ps1
+++ b/automataCI/services/compilers/installer.ps1
@@ -239,10 +239,3 @@ function INSTALLER-Setup-Python {
 
 	return 1
 }
-
-
-
-
-function INSTALLER-Setup-Reprepro {
-	return 0  # Windows do not have Reprepro
-}

--- a/automataCI/services/compilers/installer.sh
+++ b/automataCI/services/compilers/installer.sh
@@ -240,31 +240,3 @@ INSTALLER::setup_python() {
 
         return 1
 }
-
-
-
-
-INSTALLER::setup_reprepro() {
-        # validate input
-        OS::is_command_available "brew"
-        if [ $? -ne 0 ]; then
-                return 1
-        fi
-
-        OS::is_command_available "reprepro"
-        if [ $? -eq 0 ]; then
-                return 0
-        fi
-
-
-        # execute
-        brew install reprepro
-
-
-        # report status
-        if [ $? -eq 0 ]; then
-                return 0
-        fi
-
-        return 1
-}

--- a/automataCI/services/publishers/reprepro.ps1
+++ b/automataCI/services/publishers/reprepro.ps1
@@ -154,3 +154,10 @@ function REPREPRO-Publish {
 
 	return 1
 }
+
+
+
+
+function REPREPRO-Setup {
+	return 0  # Windows do not have Reprepro
+}

--- a/automataCI/services/publishers/reprepro.sh
+++ b/automataCI/services/publishers/reprepro.sh
@@ -197,3 +197,30 @@ REPREPRO_Publish() {
         # report status
         return 0
 }
+
+
+
+
+REPREPRO_Setup() {
+        # validate input
+        OS::is_command_available "brew"
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+        OS::is_command_available "reprepro"
+        if [ $? -eq 0 ]; then
+                return 0
+        fi
+
+
+        # execute
+        brew install reprepro
+        if [ $? -ne 0 ]; then
+                return 1
+        fi
+
+
+        # report status
+        return 0
+}


### PR DESCRIPTION
There were some left-over changes discovered from the current implementations. Hence, let's backport it back to reprepro publisher.

This patch backports reprepro changes in automataCI/ directory.