### PR TITLE
automataCI: added i18n feature to release docker function

### DIFF
--- a/automataCI/_package-docker_unix-any.sh
+++ b/automataCI/_package-docker_unix-any.sh
@@ -30,7 +30,7 @@ fi
 
 
 
-PACKAGE_Run_Docker() {
+PACKAGE_Run_DOCKER() {
         #__line="$1"
 
 

--- a/automataCI/_release-docker_unix-any.sh
+++ b/automataCI/_release-docker_unix-any.sh
@@ -10,14 +10,15 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/docker.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/compilers/docker.sh"
+
+. "${LIBS_AUTOMATACI}/services/i18n/status-run.sh"
 
 
 
 
-RELEASE::run_docker() {
+RELEASE_Run_DOCKER() {
         _target="$1"
         _directory="$2"
 
@@ -28,27 +29,26 @@ RELEASE::run_docker() {
                 return 0
         fi
 
-        OS::print_status info "checking required docker availability...\n"
+        I18N_Status_Print_Check_Availability "DOCKER"
         DOCKER_Is_Available
         if [ $? -ne 0 ]; then
-                OS::print_status warning "Docker is unavailable. Skipping...\n"
-                return 0
+                I18N_Status_Print_Check_Availability_Failed "DOCKER"
+                return 1
         fi
 
 
         # execute
-        OS::print_status info "releasing docker as the latest version...\n"
-        if [ ! -z "$PROJECT_SIMULATE_RELEASE_REPO" ]; then
-                OS::print_status warning "Simulating multiarch docker manifest release...\n"
-                OS::print_status warning "Simulating remove package artifact...\n"
+        I18N_Status_Print_Run_Publish "DOCKER"
+        if [ $(STRINGS_Is_Empty "$PROJECT_SIMULATE_RELEASE_REPO") -ne 0 ]; then
+                I18N_Status_Print_Run_Publish_Simulated "DOCKER"
         else
                 DOCKER_Release "$_target" "$PROJECT_VERSION"
                 if [ $? -ne 0 ]; then
-                        OS::print_status error "release failed.\n"
+                        I18N_Status_Print_Run_Publish_Failed
                         return 1
                 fi
 
-                OS::print_status info "remove package artifact...\n"
+                I18N_Status_Print_Run_Clean "$_target"
                 FS::remove_silently "$_target"
         fi
 

--- a/automataCI/_release-docker_windows-any.ps1
+++ b/automataCI/_release-docker_windows-any.ps1
@@ -9,9 +9,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\os.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\compilers\docker.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\compilers\docker.ps1"
+
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-run.ps1"
 
 
 
@@ -24,32 +25,31 @@ function RELEASE-Run-DOCKER {
 
 
 	# validate input
-	$__process = DOCKER-Is-Valid "${_target}"
-	if ($__process -ne 0) {
+	$___process = DOCKER-Is-Valid "${_target}"
+	if ($___process -ne 0) {
 		return 0
 	}
 
-	OS-Print-Status info "checking required docker availability..."
+	$null = I18N-Status-Print-Check-Availability "DOCKER"
 	$__process = DOCKER-Is-Available
 	if ($__process -ne 0) {
-		OS-Print-Status warning "Docker is unavailable. Skipping..."
-		return 0
+		$null = I18N-Status-Print-Check-Availability-Failed "DOCKER"
+		return 1
 	}
 
 
 	# execute
-	OS-Print-Status info "releasing docker as the latest version..."
-	if (-not ([string]::IsNullOrEmpty(${env:PROJECT_SIMULATE_RELEASE_REPO}))) {
-		OS-Print-Status warning "Simulating multiarch docker manifest release..."
-		OS-Print-Status warning "Simulating remove package artifact..."
+	$null = I18N-Status-Print-Run-Publish "DOCKER"
+	if ($(STRINGS-Is-Empty "${env:PROJECT_SIMULATE_RELEASE_REPO}") -ne 0) {
+		$null = I18N-Status-Print-Run-Publish-Simulated "DOCKER"
 	} else {
-		$__process = DOCKER-Release "${_target}" "${env:PROJECT_VERSION}"
-		if ($__process -ne 0) {
-			OS-Print-Status error "release failed."
+		$___process = DOCKER-Release "${_target}" "${env:PROJECT_VERSION}"
+		if ($___process -ne 0) {
+			$null = I18N-Status-Print-Run-Publish-Failed
 			return 1
 		}
 
-		OS-Print-Status info "remove package artifact..."
+		$null = I18N-Status-Print-Run-Clean "${_target}"
 		$null = FS-Remove-Silently "${_target}"
 	}
 

--- a/automataCI/package_unix-any.sh
+++ b/automataCI/package_unix-any.sh
@@ -207,7 +207,7 @@ ${__common}|${FILE_CHANGELOG_DEB}|${__log}|PACKAGE_Run_DEB
 
         __log="${__log_directory}/docker_${TARGET_FILENAME}_${TARGET_OS}-${TARGET_ARCH}.log"
         FS::append_file "$__series_control" "\
-${__common}|${__log}|PACKAGE_Run_Docker
+${__common}|${__log}|PACKAGE_Run_DOCKER
 "
         if [ $? -ne 0 ]; then
                 return 1

--- a/automataCI/release_unix-any.sh
+++ b/automataCI/release_unix-any.sh
@@ -105,7 +105,7 @@ for TARGET in "${PROJECT_PATH_ROOT}/${PROJECT_PATH_PKG}"/*; do
                 return 1
         fi
 
-        RELEASE::run_docker "$TARGET"
+        RELEASE_Run_DOCKER "$TARGET"
         if [ $? -ne 0 ]; then
                 return 1
         fi

--- a/automataCI/release_windows-any.ps1
+++ b/automataCI/release_windows-any.ps1
@@ -108,8 +108,8 @@ if (Test-Path -PathType Container -Path "${PACKAGE_DIRECTORY}") {
 			return 1
 		}
 
-		$__process = RELEASE-Run-DOCKER "$TARGET"
-		if ($__process -ne 0) {
+		$___process = RELEASE-Run-DOCKER "$TARGET"
+		if ($___process -ne 0) {
 			return 1
 		}
 

--- a/automataCI/services/compilers/docker.sh
+++ b/automataCI/services/compilers/docker.sh
@@ -265,13 +265,12 @@ DOCKER_Login() {
                 | docker login "$1" \
                         --username "$CONTAINER_USERNAME" \
                         --password-stdin
-
-
-        # report status
         if [ $? -ne 0 ]; then
                 return 1
         fi
 
+
+        # report status
         return 0
 }
 
@@ -314,7 +313,7 @@ DOCKER_Release() {
         ___list=""
         ___repo=""
         ___sku=""
-        old_IFS="$IFS"
+        ___old_IFS="$IFS"
         while IFS="" read -r ___line || [ -n "$___line" ]; do
                 if [ $(STRINGS_Is_Empty "$___line") -eq 0 ] || [ "$___line" == "\n" ]; then
                         continue
@@ -331,7 +330,7 @@ DOCKER_Release() {
 
                 ___list="${___list}--amend $___entry"
         done < "$___target"
-        IFS="$old_IFS" && unset old_IFS ___line
+        IFS="$___old_IFS" && unset ___old_IFS ___line
 
         if [ $(STRINGS_Is_Empty "$___list") -eq 0 ] ||
                 [ $(STRINGS_Is_Empty "$___repo") -eq 0 ] ||


### PR DESCRIPTION
Since we want i18n feature to be applied across all release CI job, we should first deal with release docker function. Hence, let's do this.

This patch applies i18n feature to release docker function in automataCI/ directory.