### PR TITLE
automataCI: added i18n feature to release docs function

### DIFF
--- a/automataCI/_release-docsrepo_unix-any.sh
+++ b/automataCI/_release-docsrepo_unix-any.sh
@@ -10,33 +10,33 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/versioners/git.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/versioners/git.sh"
+
+. "${LIBS_AUTOMATACI}/services/i18n/status-file.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/status-repo.sh"
 
 
 
 
-RELEASE::docs_repo() {
+RELEASE_Conclude_DOCS() {
         # validate input
-        OS::print_status info "publishing artifacts to docs repo...\n"
-        if [ ! -d "${PROJECT_PATH_ROOT}/${PROJECT_PATH_DOCS}" ]; then
-                OS::print_status warning "release skipped - No docs directory.\n"
+        I18N_Status_Print_Repo_Check "DOCS"
+        FS::is_directory "${PROJECT_PATH_ROOT}/${PROJECT_PATH_DOCS}"
+        if [ $? -ne 0 ]; then
                 return 0
         fi
 
-
-        # clean up base directory
-        OS::print_status info "safety checking docs repo directory...\n"
-        if [ -f "${PROJECT_PATH_ROOT}/${PROJECT_PATH_RELEASE}/${PROJECT_DOCS_REPO_DIRECTORY}" ]; then
-                OS::print_status error "check failed.\n"
+        FS::is_file "${PROJECT_PATH_ROOT}/${PROJECT_PATH_RELEASE}"
+        if [ $? -eq 0 ]; then
+                I18N_Status_Print_Repo_Check_Failed
                 return 1
         fi
         FS::make_directory "${PROJECT_PATH_ROOT}/${PROJECT_PATH_RELEASE}"
 
 
         # execute
-        OS::print_status info "setting up release docs repo...\n"
+        I18N_Status_Print_Repo_Setup "DOCS"
         GIT_Clone_Repo \
                 "$PROJECT_PATH_ROOT" \
                 "$PROJECT_PATH_RELEASE" \
@@ -46,42 +46,39 @@ RELEASE::docs_repo() {
                 "$PROJECT_DOCS_REPO_DIRECTORY" \
                 "$PROJECT_DOCS_REPO_BRANCH"
         if [ $? -ne 0 ]; then
-                OS::print_status error "setup failed.\n"
+                I18N_Status_Print_Repo_Setup_Failed
                 return 1
         fi
 
 
-        # move existing items to docs repo
+        # export contents
         __staging="${PROJECT_PATH_ROOT}/${PROJECT_PATH_DOCS}"
         __dest="${PROJECT_PATH_ROOT}/${PROJECT_PATH_RELEASE}/${PROJECT_DOCS_REPO_DIRECTORY}"
 
-        OS::print_status info "exporting staging contents to docs repo...\n"
+        I18N_Status_Print_File_Export "$__staging"
         FS::copy_all "${__staging}/" "$__dest"
         if [ $? -ne 0 ]; then
-                OS::print_status error "export failed.\n"
+                I18N_Status_Print_File_Export_Failed
                 return 1
         fi
 
-        OS::print_status info "Sourcing commit id for tagging...\n"
+        I18N_Status_Print_Repo_Commit "DOCS"
         __tag="$(GIT_Get_Latest_Commit_ID)"
-        if [ -z "$__tag" ]; then
-                OS::print_status error "Source failed.\n"
+        if [ $(STRINGS_Is_Empty "$__tag") -eq 0 ]; then
+                I18N_Status_Print_Repo_Commit_Failed
                 return 1
         fi
 
-        __current_path="$PWD" && cd "${__dest}"
-
-        OS::print_status info "Committing docs repo...\n"
+        ___current_path="$PWD" && cd "${__dest}"
         GIT_Autonomous_Force_Commit \
                 "$__tag" \
                 "$PROJECT_DOCS_REPO_KEY" \
                 "$PROJECT_DOCS_REPO_BRANCH"
-        __exit=$?
+        ___process=$?
+        cd "$___current_path" && unset ___current_path
 
-        cd "$__current_path" && unset __current_path
-
-        if [ $__exit -ne 0 ]; then
-                OS::print_status error "commit failed.\n"
+        if [ $___process -ne 0 ]; then
+                I18N_Status_Print_Repo_Commit_Failed
                 return 1
         fi
 

--- a/automataCI/release_unix-any.sh
+++ b/automataCI/release_unix-any.sh
@@ -184,7 +184,7 @@ else
                 return 1
         fi
 
-        RELEASE::docs_repo
+        RELEASE_Conclude_DOCS
         if [ $? -ne 0 ]; then
                 return 1
         fi

--- a/automataCI/release_windows-any.ps1
+++ b/automataCI/release_windows-any.ps1
@@ -188,8 +188,8 @@ if (-not ([string]::IsNullOrEmpty(${env:PROJECT_SIMULATE_RELEASE_REPO}))) {
 		return 1
 	}
 
-	$__process = RELEASE-Docs-Repo
-	if ($__process -ne 0) {
+	$___process = RELEASE-Conclude-DOCS
+	if ($___process -ne 0) {
 		return 1
 	}
 }


### PR DESCRIPTION
Since we want i18n feature to be applied across all release CI job, we should first deal with release docs function. Hence, let's do this.

This patch applies i18n feature to release docs function in automataCI/ directory.