### PR TITLE
automataCI: backported changes to io/time library

### DIFF
--- a/automataCI/services/io/time.ps1
+++ b/automataCI/services/io/time.ps1
@@ -11,19 +11,19 @@
 # under the License.
 function TIME-Format-ISO8601-Date {
 	param(
-		[string]$__epoch
+		[string]$___epoch
 	)
 
 
 	# validate input
-	if ([string]::IsNullOrEmpty($__epoch)) {
+	if ([string]::IsNullOrEmpty($___epoch)) {
 		return 1
 	}
 
 
 	# execute
-	$__t = (Get-Date "1970-01-01 00:00:00.000Z") + ([TimeSpan]::FromSeconds($__epoch))
-	return $__t.ToString("yyyy-MM-dd")
+	$___t = (Get-Date "1970-01-01 00:00:00.000Z") + ([TimeSpan]::FromSeconds($___epoch))
+	return $___t.ToString("yyyy-MM-dd")
 }
 
 

--- a/automataCI/services/io/time.sh
+++ b/automataCI/services/io/time.sh
@@ -11,7 +11,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 TIME_Format_ISO8601_Date() {
-        #__epoch="$1"
+        #___epoch="$1"
 
 
         # validate input


### PR DESCRIPTION
Since the io/time library was left out, we should backport all the new changes for it. Hence, let's do this.

This patch backports changes to io/time library in automataCI/ directory.