### PR TITLE
automataCI: backported changes to flatpak packaging function

### DIFF
--- a/automataCI/_package-flatpak_unix-any.sh
+++ b/automataCI/_package-flatpak_unix-any.sh
@@ -30,7 +30,7 @@ fi
 
 
 
-PACKAGE_Run_Flatpak() {
+PACKAGE_Run_FLATPAK() {
         #__line="$1"
 
 

--- a/automataCI/package_unix-any.sh
+++ b/automataCI/package_unix-any.sh
@@ -216,7 +216,7 @@ ${__common}|${__log}|PACKAGE_Run_DOCKER
         __flatpak_path="${PROJECT_PATH_ROOT}/${PROJECT_PATH_TEMP}/${PROJECT_PATH_RELEASE}/flatpak"
         __log="${__log_directory}/flatpak_${TARGET_FILENAME}_${TARGET_OS}-${TARGET_ARCH}.log"
         FS::append_file "$__series_control" "\
-${__common}|${__flatpak_path}|${__log}|PACKAGE_Run_Flatpak
+${__common}|${__flatpak_path}|${__log}|PACKAGE_Run_FLATPAK
 "
         if [ $? -ne 0 ]; then
                 return 1


### PR DESCRIPTION
There were some new changes done and flatpak packaging function was left out. Hence, let's backport them back to it.

This patch backports changes to flatpak packaging function in automataCI/ directory.