### PR TITLE
automataCI: added i18n feature to release rpm function

### DIFF
--- a/automataCI/_release-deb_windows-any.ps1
+++ b/automataCI/_release-deb_windows-any.ps1
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 . "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
 . "${env:LIBS_AUTOMATACI}\services\compilers\deb.ps1"
 . "${env:LIBS_AUTOMATACI}\services\publishers\reprepro.ps1"
 
@@ -68,7 +69,7 @@ function RELEASE-Run-DEB {
 	}
 
 	$null = I18N-Status-Print-Run-Publish "REPREPRO"
-	if ([string]::IsNullOrEmpty(${env:PROJECT_SIMULATE_RELEASE_REPO})) {
+	if ($(STRINGS-Is-Empty "${env:PROJECT_SIMULATE_RELEASE_REPO}") -ne 0) {
 		$null = I18N-Status-Print-Run-Publish-Simulated "REPREPRO"
 	} else {
 		$___process = REPREPRO-Publish `

--- a/automataCI/_release-rpm_unix-any.sh
+++ b/automataCI/_release-rpm_unix-any.sh
@@ -10,15 +10,17 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/rpm.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/publishers/createrepo.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/compilers/rpm.sh"
+. "${LIBS_AUTOMATACI}/services/publishers/createrepo.sh"
+
+. "${LIBS_AUTOMATACI}/services/i18n/status-file.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/status-run.sh"
 
 
 
 
-RELEASE::run_rpm() {
+RELEASE_Run_RPM() {
         __target="$1"
         __directory="$2"
 
@@ -29,27 +31,27 @@ RELEASE::run_rpm() {
                 return 0
         fi
 
-        OS::print_status info "checking required createrepo availability...\n"
-        CREATEREPO::is_available
+        I18N_Status_Print_Check_Availability "CREATEREPO"
+        CREATEREPO_Is_Available
         if [ $? -ne 0 ]; then
-                OS::print_status warning "Createrepo is unavailable. Skipping...\n"
+                I18N_Status_Print_Check_Availability_Failed "CREATEREPO"
                 return 0
         fi
 
 
         # execute
         __dest="${2}/rpm"
-        OS::print_status info "creating destination path: ${__dest}\n"
+        I18N_Status_Print_File_Create "$__dest"
         FS::make_directory "${__dest}"
         if [ $? -ne 0 ]; then
-                OS::print_status error "create failed.\n"
+                I18N_Status_Print_File_Create_Failed
                 return 1
         fi
 
-        OS::print_status info "publishing with createrepo...\n"
-        CREATEREPO::publish "$__target" "${__dest}"
+        I18N_Status_Print_Run_Publish "CREATEREPO"
+        CREATEREPO_Publish "$__target" "${__dest}"
         if [ $? -ne 0 ]; then
-                OS::print_status error "publish failed.\n"
+                I18N_Status_Print_Run_Publish_Failed
                 return 1
         fi
 

--- a/automataCI/_release-rpm_windows-any.ps1
+++ b/automataCI/_release-rpm_windows-any.ps1
@@ -9,10 +9,13 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\os.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\compilers\rpm.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\publishers\createrepo.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
+. "${env:LIBS_AUTOMATACI}\services\compilers\rpm.ps1"
+. "${env:LIBS_AUTOMATACI}\services\publishers\createrepo.ps1"
+
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-file.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\status-run.ps1"
 
 
 
@@ -25,32 +28,32 @@ function RELEASE-Run-RPM {
 
 
 	# validate input
-	$__process = RPM-Is-Valid "${__target}"
-	if ($__process -ne 0) {
+	$___process = RPM-Is-Valid "${__target}"
+	if ($___process -ne 0) {
 		return 0
 	}
 
-	OS-Print-Status info "checking required createrepo availability..."
-	$__process = CREATEREPO-Is-Available
-	if ($__process -ne 0) {
-		OS-Print-Status warning "Createrepo is unavailable. Skipping..."
+	$null = I18N-Status-Print-Check-Availability "CREATEREPO"
+	$___process = CREATEREPO-Is-Available
+	if ($___process -ne 0) {
+		$null = I18N-Status-Print-Check-Availability-Failed "CREATEREPO"
 		return 0
 	}
 
 
 	# execute
 	$__dest = "${__directory}/rpm"
-	OS-Print-Status info "creating destination path..."
-	$__process = FS-Make-Directory "${__dest}"
-	if ($__process -ne 0) {
-		OS-Print-Status error "create failed."
+	$null = I18N-Status-Print-File-Create "${__dest}"
+	$___process = FS-Make-Directory "${__dest}"
+	if ($___process -ne 0) {
+		$null = I18N-Status-Print-File-Create-Failed
 		return 1
 	}
 
-	OS-Print-Status info "publishing with createrepo..."
-	$__process = CREATEREPO-Publish "${__target}" "${__dest}"
-	if ($__process -ne 0) {
-		OS-Print-Status error "publish failed."
+	$null = I18N-Status-Print-Run-Publish "CREATEREPO"
+	$___process = CREATEREPO-Publish "${__target}" "${__dest}"
+	if ($___process -ne 0) {
+		$null = I18N-Status-Print-Run-Publish-Failed
 		return 1
 	}
 

--- a/automataCI/release_unix-any.sh
+++ b/automataCI/release_unix-any.sh
@@ -100,7 +100,7 @@ for TARGET in "${PROJECT_PATH_ROOT}/${PROJECT_PATH_PKG}"/*; do
                 return 1
         fi
 
-        RELEASE::run_rpm "$TARGET" "$STATIC_REPO"
+        RELEASE_Run_RPM "$TARGET" "$STATIC_REPO"
         if [ $? -ne 0 ]; then
                 return 1
         fi

--- a/automataCI/services/publishers/createrepo.ps1
+++ b/automataCI/services/publishers/createrepo.ps1
@@ -9,21 +9,22 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\os.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\os.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
 
 
 
 
 function CREATEREPO-Is-Available {
 	# execute
-	$__process = OS-Is-Command-Available "createrepo"
-	if ($__process -eq 0) {
+	$___process = OS-Is-Command-Available "createrepo"
+	if ($___process -eq 0) {
 		return 0
 	}
 
-	$__process = OS-Is-Command-Available "createrepo_c"
-	if ($__process -eq 0) {
+	$___process = OS-Is-Command-Available "createrepo_c"
+	if ($___process -eq 0) {
 		return 0
 	}
 
@@ -37,38 +38,46 @@ function CREATEREPO-Is-Available {
 
 function CREATEREPO-Publish {
 	param (
-		[string]$__target,
-		[string]$__directory
+		[string]$___target,
+		[string]$___directory
 	)
 
 
 	# validate input
-	if ([string]::IsNullOrEmpty($__target) -or
-		[string]::IsNullOrEmpty($__directory) -or
-		(Test-Path "${__target}" -PathType Container) -or
-		(-not (Test-Path "${__directory}" -PathType Container))) {
+	if (($(STRINGS-Is-Empty "${___target}") -eq 0) -or
+		($(STRINGS-Is-Empty "${___directory}") -eq 0)) {
+		return 1
+	}
+
+	$___process = FS-Is-Directory "${___target}"
+	if ($___process -eq 0) {
+		return 1
+	}
+
+	$___process = FS-Is-Directory "${___directory}"
+	if ($___process -ne 0) {
 		return 1
 	}
 
 
 	# execute
-	$__process = FS-Copy-File "${__target}" "${__directory}"
-	if ($__process -ne 0) {
+	$___process = FS-Copy-File "${___target}" "${___directory}"
+	if ($___process -ne 0) {
 		return 1
 	}
 
-	$__process = OS-Is-Command-Available "createrepo"
-	if ($__process -eq 0) {
-		$__process = OS-Exec "createrepo" "--update ${__directory}"
-		if ($__process -eq 0) {
+	$___process = OS-Is-Command-Available "createrepo"
+	if ($___process -eq 0) {
+		$___process = OS-Exec "createrepo" "--update ${___directory}"
+		if ($___process -eq 0) {
 			return 0
 		}
 	}
 
-	$__process = OS-Is-Command-Available "createrepo_c"
-	if ($__process -eq 0) {
-		$__process = OS-Exec "createrepo_c" "--update ${__directory}"
-		if ($__process -eq 0) {
+	$___process = OS-Is-Command-Available "createrepo_c"
+	if ($___process -eq 0) {
+		$___process = OS-Exec "createrepo_c" "--update ${___directory}"
+		if ($___process -eq 0) {
 			return 0
 		}
 	}

--- a/automataCI/services/publishers/createrepo.sh
+++ b/automataCI/services/publishers/createrepo.sh
@@ -10,13 +10,14 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/os.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/strings.sh"
 
 
 
 
-CREATEREPO::is_available() {
+CREATEREPO_Is_Available() {
         # execute
         OS::is_command_available "createrepo"
         if [ $? -eq 0 ]; then
@@ -36,16 +37,24 @@ CREATEREPO::is_available() {
 
 
 
-CREATEREPO::publish() {
-        __target="$1"
-        __directory="$2"
+CREATEREPO_Publish() {
+        ___target="$1"
+        ___directory="$2"
 
 
         # validate input
-        if [ -z "$__target" ] ||
-                [ -z "$__directory" ] ||
-                [ -d "$__target" ] ||
-                [ ! -d "$__directory" ]; then
+        if [ $(STRINGS_Is_Empty "$___target") -eq 0 ] ||
+                [ $(STRINGS_Is_Empty "$__directory") -eq 0 ]; then
+                return 1
+        fi
+
+        FS::is_directory "$___target"
+        if [ $? -eq 0 ]; then
+                return 1
+        fi
+
+        FS::is_directory "$___directory"
+        if [ $? -ne 0 ]; then
                 return 1
         fi
 


### PR DESCRIPTION
Since we want i18n feature to be applied across all release CI job, we should first deal with release rpm function in automataCI/ directory. Hence, let's do this.

This patch applies i18n feature to release rpm function in autoamtaCI/ directory.