### PR TITLE
automataCI: refactored STRINGS library to match latest specs

### DIFF
--- a/automataCI/_package-homebrew_unix-any.sh
+++ b/automataCI/_package-homebrew_unix-any.sh
@@ -136,13 +136,13 @@ PACKAGE_Run_HOMEBREW() {
         FS::remove_silently "${_target_path}.rb"
         __old_IFS="$IFS"
         while IFS= read -r __line || [ -n "$__line" ]; do
-                __line="$(STRINGS::replace_all \
+                __line="$(STRINGS_Replace_All \
                         "$__line" \
                         "{{ TARGET_PACKAGE }}" \
                         "${_target_path##*/}.tar.xz" \
                 )"
 
-                __line="$(STRINGS::replace_all \
+                __line="$(STRINGS_Replace_All \
                         "$__line" \
                         "{{ TARGET_SHASUM }}" \
                         "${__shasum}" \

--- a/automataCI/_package-sourcing_unix-any.sh
+++ b/automataCI/_package-sourcing_unix-any.sh
@@ -41,7 +41,7 @@ old_IFS="$IFS"
 while IFS="" read -r tech || [ -n "$tech" ]; do
         # validate input
         if [ $(STRINGS_Is_Empty "$tech") -eq 0 ] ||
-                [ "$(STRINGS::to_uppercase "$tech")" = "NONE" ]; then
+                [ "$(STRINGS_To_Uppercase "$tech")" = "NONE" ]; then
                 continue
         fi
 

--- a/automataCI/common_unix-any.sh
+++ b/automataCI/common_unix-any.sh
@@ -51,11 +51,11 @@ BASELINE|${PROJECT_PATH_SOURCE:-none}
 old_IFS="$IFS"
 while IFS= read -r tech || [ -n "$tech" ]; do
         if [ $(STRINGS_Is_Empty "${tech#*|}") -eq 0 ] ||
-                [ "$(STRINGS::to_uppercase "${tech#*|}")" = "NONE" ]; then
+                [ "$(STRINGS_To_Uppercase "${tech#*|}")" = "NONE" ]; then
                 continue
         fi
 
-        if [ ! "$(STRINGS::to_uppercase "${tech%|*}")" = "BASELINE" ]; then
+        if [ ! "$(STRINGS_To_Uppercase "${tech%|*}")" = "BASELINE" ]; then
                 case "$1" in
                 deploy)
                         continue # skipped
@@ -67,7 +67,7 @@ while IFS= read -r tech || [ -n "$tech" ]; do
 
 
         # execute
-        ci_job="$(STRINGS::to_lowercase "${PROJECT_CI_JOB}")_unix-any.sh"
+        ci_job="$(STRINGS_To_Lowercase "${PROJECT_CI_JOB}")_unix-any.sh"
         ci_job="${PROJECT_PATH_ROOT}/${tech#*|}/${PROJECT_PATH_CI}/${ci_job}"
         FS::is_file "$ci_job"
         if [ $? -eq 0 ]; then

--- a/automataCI/notarize_unix-any.sh
+++ b/automataCI/notarize_unix-any.sh
@@ -68,7 +68,7 @@ for i in "${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}"/*; do
                 continue
         fi
 
-        STRINGS::has_prefix "$PROJECT_SKU" "$TARGET_FILENAME"
+        STRINGS_Has_Prefix "$PROJECT_SKU" "$TARGET_FILENAME"
         if [ $? -ne 0 ]; then
                 I18N_Is_Incompatible_Skipped "$TARGET_FILENAME"
                 continue

--- a/automataCI/operators_unix-any.sh
+++ b/automataCI/operators_unix-any.sh
@@ -250,9 +250,9 @@ BUILD::_exec_build() {
 
         OS::print_status info "validating ${_target_os}-${_target_arch} ${_target_type}...\n"
         _target="${PROJECT_SKU}_${_target_os}-${_target_arch}"
-        _target_arch="$(STRINGS::to_lowercase "$_target_arch")"
+        _target_arch="$(STRINGS_To_Lowercase "$_target_arch")"
         _target_directory="${PROJECT_PATH_ROOT}/${PROJECT_PATH_TEMP}"
-        case "$(STRINGS::to_lowercase "$_target_type")" in
+        case "$(STRINGS_To_Lowercase "$_target_type")" in
         nim-binary)
                 _target_source="$PROJECT_NIM"
                 _target_type="none"

--- a/automataCI/package_unix-any.sh
+++ b/automataCI/package_unix-any.sh
@@ -162,7 +162,7 @@ for i in "${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}"/*; do
                 continue
         fi
 
-        STRINGS::has_prefix "$PROJECT_SKU" "$TARGET_FILENAME"
+        STRINGS_Has_Prefix "$PROJECT_SKU" "$TARGET_FILENAME"
         if [ $? -ne 0 ]; then
                 I18N_Is_Incompatible_Skipped "$TARGET_FILENAME"
                 continue

--- a/automataCI/services/compilers/deb.sh
+++ b/automataCI/services/compilers/deb.sh
@@ -436,7 +436,7 @@ DEB_Get_Architecture() {
 
 
         # report status
-        ___output="$(STRINGS::to_lowercase "$___output")"
+        ___output="$(STRINGS_To_Lowercase "$___output")"
         printf -- "%b" "$___output"
         return 0
 }

--- a/automataCI/services/compilers/docker.sh
+++ b/automataCI/services/compilers/docker.sh
@@ -181,13 +181,13 @@ DOCKER_Get_ID() {
 
         # execute
         if [ $(STRINGS_Is_Empty "$4") -ne 0 ] && [ $(STRINGS_Is_Empty "$5") -ne 0 ]; then
-                printf "$(STRINGS::to_lowercase "${1}/${2}:${4}-${5}_${3}")"
+                printf "$(STRINGS_To_Lowercase "${1}/${2}:${4}-${5}_${3}")"
         elif [ $(STRINGS_Is_Empty "$4") -eq 0 ] && [ $(STRINGS_Is_Empty "$5") -ne 0 ]; then
-                printf "$(STRINGS::to_lowercase "${1}/${2}:${5}_${3}")"
+                printf "$(STRINGS_To_Lowercase "${1}/${2}:${5}_${3}")"
         elif [ $(STRINGS_Is_Empty "$4") -ne 0 ] && [ $(STRINGS_Is_Empty "$5") -eq 0 ]; then
-                printf "$(STRINGS::to_lowercase "${1}/${2}:${4}_${3}")"
+                printf "$(STRINGS_To_Lowercase "${1}/${2}:${4}_${3}")"
         else
-                printf "$(STRINGS::to_lowercase "${1}/${2}:${3}")"
+                printf "$(STRINGS_To_Lowercase "${1}/${2}:${3}")"
         fi
 
 

--- a/automataCI/services/compilers/ipk.sh
+++ b/automataCI/services/compilers/ipk.sh
@@ -167,7 +167,7 @@ IPK_Get_Architecture() {
 
 
         # report status
-        printf -- "%b" "$(STRINGS::to_lowercase "${1}-${2}")"
+        printf -- "%b" "$(STRINGS_To_Lowercase "${1}-${2}")"
         return 0
 }
 

--- a/automataCI/services/compilers/python.sh
+++ b/automataCI/services/compilers/python.sh
@@ -296,7 +296,7 @@ PYTHON_Is_Valid_PYPI() {
 
 
         # execute
-        STRINGS::has_prefix "pypi" "${1##*/}"
+        STRINGS_Has_Prefix "pypi" "${1##*/}"
         if [ $? -ne 0 ]; then
                 return 1
         fi

--- a/automataCI/services/compilers/rust.sh
+++ b/automataCI/services/compilers/rust.sh
@@ -134,7 +134,7 @@ RUST_Crate_Is_Valid() {
 
 
         # execute
-        STRINGS::has_prefix "cargo" "${1##*/}"
+        STRINGS_Has_Prefix "cargo" "${1##*/}"
         if [ $? -ne 0 ]; then
                 return 1
         fi

--- a/automataCI/services/io/strings.ps1
+++ b/automataCI/services/io/strings.ps1
@@ -1,4 +1,4 @@
-# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy
@@ -11,20 +11,20 @@
 # under the License.
 function STRINGS-Has-Prefix {
 	param(
-		[string]$__prefix,
-		[string]$__content
+		[string]$___prefix,
+		[string]$___content
 	)
 
 
 	# validate input
-	$__process = STRINGS-Is-Empty "${__prefix}"
-	if ($__process -eq 0) {
+	$___process = STRINGS-Is-Empty "${___prefix}"
+	if ($___process -eq 0) {
 		return 1
 	}
 
 
 	# execute
-	if ($__content.StartsWith($__prefix)) {
+	if ($___content.StartsWith($___prefix)) {
 		return 0
 	}
 
@@ -38,20 +38,20 @@ function STRINGS-Has-Prefix {
 
 function STRINGS-Has-Suffix {
 	param(
-		[string]$__suffix,
-		[string]$__content
+		[string]$___suffix,
+		[string]$___content
 	)
 
 
 	# validate input
-	$__process = STRINGS-Is-Empty "${__suffix}"
-	if ($__process -eq 0) {
+	$___process = STRINGS-Is-Empty "${___suffix}"
+	if ($___process -eq 0) {
 		return 1
 	}
 
 
 	# execute
-	if ($__content.EndsWith($__suffix)) {
+	if ($___content.EndsWith($___suffix)) {
 		return 0
 	}
 
@@ -65,12 +65,12 @@ function STRINGS-Has-Suffix {
 
 function STRINGS-Is-Empty {
 	param(
-		$__target
+		$___target
 	)
 
 
 	# execute
-	if ([string]::IsNullOrEmpty($__target)) {
+	if ([string]::IsNullOrEmpty($___target)) {
 		return 0
 	}
 
@@ -84,47 +84,47 @@ function STRINGS-Is-Empty {
 
 function STRINGS-Replace-All {
 	param(
-		[string]$__content,
-		[string]$__subject,
-		[string]$__replacement
+		[string]$___content,
+		[string]$___subject,
+		[string]$___replacement
 	)
 
 
 	# validate input
-	$__process = STRINGS-Is-Empty "${__content}"
-	if ($__process -eq 0) {
+	$___process = STRINGS-Is-Empty "${___content}"
+	if ($___process -eq 0) {
 		return ""
 	}
 
-	$__process = STRINGS-Is-Empty "${__subject}"
-	if ($__process -eq 0) {
-		return $__content
+	$___process = STRINGS-Is-Empty "${___subject}"
+	if ($___process -eq 0) {
+		return $___content
 	}
 
-	$__process = STRINGS-Is-Empty "${__replacement}"
-	if ($__process -eq 0) {
-		return $__content
+	$___process = STRINGS-Is-Empty "${___replacement}"
+	if ($___process -eq 0) {
+		return $___content
 	}
 
 
 	# execute
-	$__right = $__content
-	$__register = ""
-	while ($__right) {
-		$__left = $__right -replace "$($__subject).*", ""
+	$___right = $___content
+	$___register = ""
+	while ($___right) {
+		$___left = $___right -replace "$($___subject).*", ""
 
-		if ($__left -eq $__right) {
-			return "${__register}${__right}"
+		if ($___left -eq $___right) {
+			return "${___register}${___right}"
 		}
 
 		# replace this occurence
-		$__register += "${__left}${__replacement}"
-		$__right = $__right -replace "^.*?${__subject}", ""
+		$___register += "${___left}${___replacement}"
+		$___right = $___right -replace "^.*?${___subject}", ""
 	}
 
 
 	# report status
-	return $__register
+	return $___register
 }
 
 
@@ -132,10 +132,12 @@ function STRINGS-Replace-All {
 
 function STRINGS-To-Lowercase {
 	param(
-		[string]$__content
+		[string]$___content
 	)
 
-	return $__content.ToLower()
+
+	# execute
+	return $___content.ToLower()
 }
 
 
@@ -143,10 +145,12 @@ function STRINGS-To-Lowercase {
 
 function STRINGS-Trim-Whitespace-Left {
 	param(
-		[string]$__content
+		[string]$___content
 	)
 
-	return $__content.TrimStart()
+
+	# execute
+	return $___content.TrimStart()
 }
 
 
@@ -154,10 +158,12 @@ function STRINGS-Trim-Whitespace-Left {
 
 function STRINGS-Trim-Whitespace-Right {
 	param(
-		[string]$__content
+		[string]$___content
 	)
 
-	return $__content.TrimEnd()
+
+	# execute
+	return $___content.TrimEnd()
 }
 
 
@@ -165,13 +171,17 @@ function STRINGS-Trim-Whitespace-Right {
 
 function STRINGS-Trim-Whitespace {
 	param(
-		[string]$__content
+		[string]$___content
 	)
 
-	$__content = STRINGS-Trim-Whitespace-Left $__content
-	$__content = STRINGS-Trim-Whitespace-Right $__content
 
-	return $__content
+	# execute
+	$___content = STRINGS-Trim-Whitespace-Left $___content
+	$___content = STRINGS-Trim-Whitespace-Right $___content
+
+
+	# report status
+	return $___content
 }
 
 
@@ -179,8 +189,10 @@ function STRINGS-Trim-Whitespace {
 
 function STRINGS-To-Uppercase {
 	param(
-		[string]$__content
+		[string]$___content
 	)
 
-	return $__content.ToUpper()
+
+	# execute
+	return $___content.ToUpper()
 }

--- a/automataCI/services/io/strings.sh
+++ b/automataCI/services/io/strings.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -10,9 +10,9 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-STRINGS::has_prefix() {
-        #__prefix="$1"
-        #__content="$2"
+STRINGS_Has_Prefix() {
+        #___prefix="$1"
+        #___content="$2"
 
 
         # validate input
@@ -34,9 +34,9 @@ STRINGS::has_prefix() {
 
 
 
-STRINGS::has_suffix() {
-        #__suffix="$1"
-        #__content="$2"
+STRINGS_Has_Suffix() {
+        #___suffix="$1"
+        #___content="$2"
 
 
         # validate input
@@ -60,7 +60,7 @@ STRINGS::has_suffix() {
 
 
 STRINGS_Is_Empty() {
-        #__target="$1"
+        #___target="$1"
 
 
         # execute
@@ -78,10 +78,10 @@ STRINGS_Is_Empty() {
 
 
 
-STRINGS::replace_all() {
-        #__content="$1"
-        #__subject="$2"
-        #__replacement="$3"
+STRINGS_Replace_All() {
+        #___content="$1"
+        #___subject="$2"
+        #___replacement="$3"
 
 
         # validate input
@@ -102,76 +102,101 @@ STRINGS::replace_all() {
 
 
         # execute
-        __right="$1"
-        __register=""
-        while [ -n "$__right" ]; do
-                __left=${__right%%${2}*}
+        ___right="$1"
+        ___register=""
+        while [ -n "$___right" ]; do
+                ___left=${___right%%${2}*}
 
-                if [ "$__left" = "$__right" ]; then
-                        printf -- "%b" "${__register}${__right}"
+                if [ "$___left" = "$___right" ]; then
+                        printf -- "%b" "${___register}${___right}"
                         return 0
                 fi
 
                 # replace this occurence
-                __register="${__register}${__left}${3}"
-                __right="${__right#*${2}}"
+                ___register="${___register}${___left}${3}"
+                ___right="${___right#*${2}}"
         done
 
 
         # report status
-        printf -- "%b" "${__register}"
+        printf -- "%b" "${___register}"
         return 0
 }
 
 
 
 
-STRINGS::to_lowercase() {
-        #__content="$1"
+STRINGS_To_Lowercase() {
+        #___content="$1"
 
+
+        # execute
         printf -- "%b" "$1" | tr '[:upper:]' '[:lower:]'
+
+
+        # report status
         return 0
 }
 
 
 
 
-STRINGS::trim_whitespace_left() {
-        #__content="$1"
+STRINGS_Trim_Whitespace_Left() {
+        #___content="$1"
 
+
+        # execute
         printf -- "%b" "${1#"${1%%[![:space:]]*}"}"
+
+
+        # report status
         return 0
 }
 
 
 
 
-STRINGS::trim_whitespace_right() {
-        #__content="$1"
+STRINGS_Trim_Whitespace_Right() {
+        #___content="$1"
 
+
+        # execute
         printf -- "%b" "${1%"${1##*[![:space:]]}"}"
+
+
+        # report status
         return 0
 }
 
 
 
 
-STRINGS::trim_whitespace() {
-        #__content="$1"
+STRINGS_Trim_Whitespace() {
+        #___content="$1"
 
-        ___content="$(STRINGS::trim_whitespace_left "$1")"
-        ___content="$(STRINGS::trim_whitespace_right "$___content")"
+
+        # execute
+        ___content="$(STRINGS_Trim_Whitespace_Left "$1")"
+        ___content="$(STRINGS_Trim_Whitespace_Right "$___content")"
         printf -- "%b" "$___content"
         unset ___content
+
+
+        # report status
         return 0
 }
 
 
 
 
-STRINGS::to_uppercase() {
-        #__content="$1"
+STRINGS_To_Uppercase() {
+        #___content="$1"
 
+
+        # execute
         printf -- "%b" "$1" | tr '[:lower:]' '[:upper:]'
+
+
+        # report status
         return 0
 }

--- a/automataCI/services/publishers/dotnet.sh
+++ b/automataCI/services/publishers/dotnet.sh
@@ -34,7 +34,7 @@ DOTNET_Add() {
         if [ $(STRINGS_Is_Empty "$___version") -eq 0 ]; then
                 ___version="latest"
         fi
-        ___version="$(STRINGS::to_lowercase "${___version}")"
+        ___version="$(STRINGS_To_Lowercase "${___version}")"
 
 
         # execute

--- a/src/.ci/_package-msi_unix-any.sh
+++ b/src/.ci/_package-msi_unix-any.sh
@@ -154,10 +154,10 @@ Software\\\\${PROJECT_CONTACT_NAME}\\\\InstalledProducts\\\\${PROJECT_NAME}"
         old_IFS="$IFS"
         printf -- '%s' "$__selections" | while IFS="" read -r __line || [ -n "$__line" ]; do
                 # parse line
-                __arch="$(STRINGS::to_lowercase "${__line%%|*}")"
+                __arch="$(STRINGS_To_Lowercase "${__line%%|*}")"
                 __line="${__line#*|}"
 
-                __i18n="$(STRINGS::to_lowercase "${__line%%|*}")"
+                __i18n="$(STRINGS_To_Lowercase "${__line%%|*}")"
                 __line="${__line#*|}"
 
 


### PR DESCRIPTION
The io/string library is out of touch from the latest specs where the PowerShell and POSIX Shell shares a same naming convention pattern. Hence, let's refactor it.

This patch refactors STRINGS library to match the latest specs in automataCI/ directory.