### PR TITLE
src: refactored _package-rpm job for i18n and latest specs compliances

### DIFF
--- a/automataCI/services/i18n/_copy-failed.ps1
+++ b/automataCI/services/i18n/_copy-failed.ps1
@@ -1,0 +1,28 @@
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${env:LIBS_AUTOMATACI}\services\i18n\__printer.ps1"
+
+
+
+
+function I18N-Copy-Failed {
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$null = I18N-Status-Print error "copy failed.`n`n"
+	}}
+
+
+	# report status
+	return 0
+}

--- a/automataCI/services/i18n/_copy-failed.sh
+++ b/automataCI/services/i18n/_copy-failed.sh
@@ -1,0 +1,29 @@
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${LIBS_AUTOMATACI}/services/i18n/__printer.sh"
+
+
+
+
+I18N_Copy_Failed() {
+        # execute
+        case "$AUTOMATACI_LANG" in
+        *)
+                # fallback to default english
+                I18N_Status_Print error "copy failed.\n\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}

--- a/automataCI/services/i18n/_copy.ps1
+++ b/automataCI/services/i18n/_copy.ps1
@@ -1,0 +1,38 @@
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${env:LIBS_AUTOMATACI}\services\i18n\__printer.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\__param.ps1"
+
+
+
+
+function I18N-Copy {
+	param(
+		[string]$___subject
+		[string]$___target
+	)
+
+
+	# execute
+	switch (${env:AUTOMATACI_LANG}) {
+	default {
+		# fallback to default english
+		$___subject = I18N-Param-Process "${___subject}"
+		$___target = I18N-Param-Process "${___target}"
+		$null = I18N-Status-Print info `
+			"copying '${___subject}' into/as '${___target}'...`n"
+	}}
+
+
+	# report status
+	return 0
+}

--- a/automataCI/services/i18n/_copy.sh
+++ b/automataCI/services/i18n/_copy.sh
@@ -1,0 +1,32 @@
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at:
+#                 http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+. "${LIBS_AUTOMATACI}/services/i18n/__printer.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/__param.sh"
+
+
+
+
+I18N_Copy() {
+        # execute
+        case "$AUTOMATACI_LANG" in
+        *)
+                # fallback to default english
+                ___subject="$(I18N_Param_Process "$1")"
+                ___target="$(I18N_Param_Process "$2")"
+                I18N_Status_Print info "copy '${___subject}' into/as '${___target}'...\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}

--- a/src/.ci/_package-rpm_unix-any.sh
+++ b/src/.ci/_package-rpm_unix-any.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,13 +15,14 @@
 
 
 # initialize
-if [ "$PROJECT_PATH_ROOT" == "" ]; then
-        >&2 printf "[ ERROR ] - Please run from ci.cmd instead!\n"
+if [ "$PROJECT_PATH_ROOT" = "" ]; then
+        >&2 printf "[ ERROR ] - Please run from automataCI/ci.sh.ps1 instead!\n"
         return 1
 fi
 
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/os.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
 
 
 
@@ -53,22 +54,24 @@ PACKAGE_Assemble_RPM_Content() {
                 # TIP: (1) usually is: usr/local/lib
                 #      (2) please avoid: lib/, lib{TYPE}/ usr/lib/, and usr/lib{TYPE}/
                 _filepath="${_directory}/BUILD/lib${PROJECT_SKU}.a"
-                OS_Print_Status info "copying ${_target} to ${_filepath}\n"
+                I18N_Copy "$_target" "$_filepath"
                 FS_Make_Housing_Directory "$_filepath"
                 if [ $? -ne 0 ]; then
-                        OS_Print_Status error "copy failed."
+                        I18N_Copy_Failed
                         return 1
                 fi
 
                 FS_Copy_File "$_target" "$_filepath"
                 if [ $? -ne 0 ]; then
-                        OS_Print_Status error "copy failed."
+                        I18N_Copy_Failed
                         return 1
                 fi
 
 
                 # generate AutomataCI's required RPM spec instructions (INSTALL)
-                FS_Write_File "${_directory}/SPEC_INSTALL" "\
+                __file="${_directory}/SPEC_INSTALL"
+                I18N_Create "$__file"
+                FS_Write_File "$__file" "\
 install --directory %{buildroot}/usr/local/lib/${PROJECT_SKU}
 install -m 0644 lib${PROJECT_SKU}.a %{buildroot}/usr/local/lib/${PROJECT_SKU}
 
@@ -76,16 +79,20 @@ install --directory %{buildroot}/usr/local/share/doc/lib${PROJECT_SKU}/
 install -m 0644 copyright %{buildroot}/usr/local/share/doc/lib${PROJECT_SKU}/
 "
                 if [ $? -ne 0 ]; then
+                        I18N_Create_Failed
                         return 1
                 fi
 
 
                 # generate AutomataCI's required RPM spec instructions (FILES)
-                FS_Write_File "${_directory}/SPEC_FILES" "\
+                __file="${_directory}/SPEC_FILES"
+                I18N_Create "$__file"
+                FS_Write_File "$__file" "\
 /usr/local/lib/${PROJECT_SKU}/lib${PROJECT_SKU}.a
 /usr/local/share/doc/lib${PROJECT_SKU}/copyright
 "
                 if [ $? -ne 0 ]; then
+                        I18N_Create_Failed
                         return 1
                 fi
 
@@ -107,22 +114,24 @@ install -m 0644 copyright %{buildroot}/usr/local/share/doc/lib${PROJECT_SKU}/
                 # copy main program
                 # TIP: (1) copy all files into "${__directory}/BUILD" directory.
                 _filepath="${_directory}/BUILD/${PROJECT_SKU}"
-                OS_Print_Status info "copying $_target to ${_filepath}\n"
+                I18N_Copy "$_target" "$_filepath"
                 FS_Make_Housing_Directory "$_filepath"
                 if [ $? -ne 0 ]; then
-                        OS_Print_Status error "copy failed.\n"
+                        I18N_Copy_Failed
                         return 1
                 fi
 
                 FS_Copy_File "$_target" "$_filepath"
                 if [ $? -ne 0 ]; then
-                        OS_Print_Status error "copy failed.\n"
+                        I18N_Copy_Failed
                         return 1
                 fi
 
 
                 # generate AutomataCI's required RPM spec instructions (INSTALL)
-                FS_Write_File "${_directory}/SPEC_INSTALL" "\
+                __file="${_directory}/SPEC_INSTALL"
+                I18N_Create "$__file"
+                FS_Write_File "$__file" "\
 install --directory %{buildroot}/usr/local/bin
 install -m 0755 ${PROJECT_SKU} %{buildroot}/usr/local/bin
 
@@ -133,17 +142,21 @@ install --directory %{buildroot}/usr/local/share/man/man1/
 install -m 0644 ${PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
 "
                 if [ $? -ne 0 ]; then
+                        I18N_Create_Failed
                         return 1
                 fi
 
 
                 # generate AutomataCI's required RPM spec instructions (FILES)
-                FS_Write_File "${_directory}/SPEC_FILES" "\
+                __file="${_directory}/SPEC_FILES"
+                I18N_Create "$__file"
+                FS_Write_File "$__file" "\
 /usr/local/bin/${PROJECT_SKU}
 /usr/local/share/doc/${PROJECT_SKU}/copyright
 /usr/local/share/man/man1/${PROJECT_SKU}.1.gz
 "
                 if [ $? -ne 0 ]; then
+                        I18N_Create_Failed
                         return 1
                 fi
 
@@ -152,7 +165,7 @@ install -m 0644 ${PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
 
 
         # NOTE: REQUIRED file
-        OS_Print_Status info "creating copyright.gz file...\n"
+        I18N_Create "copyright.gz"
         COPYRIGHT_Create \
                 "${_directory}/BUILD/copyright" \
                 "${PROJECT_PATH_ROOT}/${PROJECT_PATH_RESOURCES}/licenses/deb-copyright" \
@@ -161,12 +174,13 @@ install -m 0644 ${PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
                 "$PROJECT_CONTACT_EMAIL" \
                 "$PROJECT_CONTACT_WEBSITE"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 
 
         # NOTE: REQUIRED file
-        OS_Print_Status info "creating man pages file...\n"
+        I18N_Create "MAN PAGES"
         MANUAL_Create \
                 "${_directory}/BUILD/${PROJECT_SKU}.1" \
                 "$PROJECT_SKU" \
@@ -174,12 +188,13 @@ install -m 0644 ${PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
                 "$PROJECT_CONTACT_EMAIL" \
                 "$PROJECT_CONTACT_WEBSITE"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 
 
         # NOTE: OPTIONAL (Comment to turn it off)
-        OS_Print_Status info "creating source.repo files...\n"
+        I18N_Create "source.repo"
         RPM_Create_Source_Repo \
                 "$PROJECT_SIMULATE_RELEASE_REPO" \
                 "$_directory" \
@@ -188,12 +203,13 @@ install -m 0644 ${PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
                 "$PROJECT_NAME" \
                 "$_gpg_keyring"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 
 
         # WARNING: THIS REQUIRED FILE MUST BE THE LAST ONE
-        OS_Print_Status info "creating spec file...\n"
+        I18N_Create "spec"
         RPM_Create_Spec \
                 "$_directory" \
                 "${PROJECT_PATH_ROOT}/${PROJECT_PATH_RESOURCES}" \
@@ -207,6 +223,7 @@ install -m 0644 ${PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
                 "$PROJECT_LICENSE" \
                 "${PROJECT_PATH_ROOT}/${PROJECT_PATH_RESOURCES}/docs/ABSTRACTS.txt"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 

--- a/src/.ci/_package-rpm_windows-any.ps1
+++ b/src/.ci/_package-rpm_windows-any.ps1
@@ -1,4 +1,4 @@
-# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy
@@ -15,12 +15,13 @@
 
 # initialize
 if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
-	Write-Error "[ ERROR ] - Please run from ci.cmd instead!\n"
+	Write-Error "[ ERROR ] - Please run from automataCI\ci.sh.ps1 instead!`n"
 	return 1
 }
 
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\os.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\os.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\translations.ps1"
 
 
 
@@ -54,39 +55,45 @@ function PACKAGE-Assemble-RPM-Content {
 		# TIP: (1) usually is: usr/local/lib
 		#      (2) please avoid: lib/, lib{TYPE}/ usr/lib/, and usr/lib{TYPE}/
 		$_filepath = "${_directory}\BUILD\lib${env:PROJECT_SKU}.a"
-		OS-Print-Status info "copying ${_target} to ${_filepath}"
-		$__process = FS-Make-Housing-Directory "${_filepath}"
-		if ($__process -ne 0) {
-			OS-Print-Status error "copy failed."
+		$null = I18N-Copy "${_target}" "${_filepath}"
+		$___process = FS-Make-Housing-Directory "${_filepath}"
+		if ($___process -ne 0) {
+			$null = I18N-Copy-Failed
 			return 1
 		}
 
-		$__process = FS-Copy-File "${_target}" "${_filepath}"
-		if ($__process -ne 0) {
-			OS-Print-Status error "copy failed."
+		$___process = FS-Copy-File "${_target}" "${_filepath}"
+		if ($___process -ne 0) {
+			$null = I18N-Copy-Failed
 			return 1
 		}
 
 
 		# generate AutomataCI's required RPM spec instructions (INSTALL)
-		$__process = FS-Write-File "${_directory}\SPEC_INSTALL" @"
+		$__file = "${_directory}\SPEC_INSTALL"
+		$null = I18N-Create "${__file}"
+		$___process = FS-Write-File "${__file}" @"
 install --directory %{buildroot}/usr/local/lib/${env:PROJECT_SKU}
 install -m 0644 lib${env:PROJECT_SKU}.a %{buildroot}/usr/local/lib/${env:PROJECT_SKU}
 
 install --directory %{buildroot}/usr/local/share/doc/lib${env:PROJECT_SKU}/
 install -m 0644 copyright %{buildroot}/usr/local/share/doc/lib${env:PROJECT_SKU}/
 "@
-		if ($__process -ne 0) {
+		if ($___process -ne 0) {
+			$null = I18N-Create-Failed
 			return 1
 		}
 
 
 		# generate AutomataCI's required RPM spec instructions (FILES)
-		$__process = FS-Write-File "${_directory}\SPEC_FILES" @"
+		$__file = "${_directory}\SPEC_FILES"
+		$null = I18N-Create "${__file}"
+		$___process = FS-Write-File "${__file}" @"
 /usr/local/lib/${env:PROJECT_SKU}/lib${env:PROJECT_SKU}.a
 /usr/local/share/doc/lib${env:PROJECT_SKU}/copyright
 "@
-		if ($__process -ne 0) {
+		if ($___process -ne 0) {
+			$null = I18N-Create-Failed
 			return 1
 		}
 
@@ -109,22 +116,24 @@ install -m 0644 copyright %{buildroot}/usr/local/share/doc/lib${env:PROJECT_SKU}
 		# TIP: (1) usually is: usr/local/bin or usr/local/sbin
 		#      (2) please avoid: bin/, usr/bin/, sbin/, and usr/sbin/
 		$_filepath = "${_directory}\BUILD\${env:PROJECT_SKU}"
-		OS-Print-Status info "copying ${_target} to ${_filepath}"
-		$__process = FS-Make-Housing-Directory "${_filepath}"
-		if ($__process -ne 0) {
-			OS-Print-Status error "copy failed."
+		$null = I18N-Copy "${_target}" "${_filepath}"
+		$___process = FS-Make-Housing-Directory "${_filepath}"
+		if ($___process -ne 0) {
+			$null = I18N-Copy-Failed
 			return 1
 		}
 
-		$__process = FS-Copy-File "${_target}" "${_filepath}"
-		if ($__process -ne 0) {
-			OS-Print-Status error "copy failed."
+		$___process = FS-Copy-File "${_target}" "${_filepath}"
+		if ($___process -ne 0) {
+			$null = I18N-Copy-Failed
 			return 1
 		}
 
 
 		# generate AutomataCI's required RPM spec instructions (INSTALL)
-		$__process = FS-Write-File "${_directory}\SPEC_INSTALL" @"
+		$__file = "${_directory}\SPEC_INSTALL"
+		$null = I18N-Create "${__file}"
+		$___process = FS-Write-File "${__file}" @"
 install --directory %{buildroot}/usr/local/bin
 install -m 0755 ${env:PROJECT_SKU} %{buildroot}/usr/local/bin
 
@@ -134,18 +143,22 @@ install -m 644 copyright %{buildroot}/usr/local/share/doc/${env:PROJECT_SKU}/
 install --directory %{buildroot}/usr/local/share/man/man1/
 install -m 644 ${env:PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
 "@
-		if ($__process -ne 0) {
+		if ($___process -ne 0) {
+			$null = I18N-Create-Failed
 			return 1
 		}
 
 
 		# generate AutomataCI's required RPM spec instructions (FILES)
-		$__process = FS-Write-File "${_directory}\SPEC_FILES" @"
+		$__file = "${_directory}\SPEC_FILES"
+		$null = I18N-Create "${__file}"
+		$___process = FS-Write-File "${__file}" @"
 /usr/local/bin/${env:PROJECT_SKU}
 /usr/local/share/doc/${env:PROJECT_SKU}/copyright
 /usr/local/share/man/man1/${env:PROJECT_SKU}.1.gz
 "@
-		if ($__process -ne 0) {
+		if ($___process -ne 0) {
+			$null = I18N-Create-Failed
 			return 1
 		}
 
@@ -154,35 +167,37 @@ install -m 644 ${env:PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
 
 
 	# NOTE: REQUIRED file
-	OS-Print-Status info "creating copyright.gz file..."
-	$__process = COPYRIGHT-Create `
+	$null = I18N-Create "copyright.gz"
+	$___process = COPYRIGHT-Create `
 		"${_directory}\BUILD\copyright" `
 		"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\licenses\deb-copyright" `
 		${env:PROJECT_SKU} `
 		${env:PROJECT_CONTACT_NAME} `
 		${env:PROJECT_CONTACT_EMAIL} `
 		${env:PROJECT_CONTACT_WEBSITE}
-	if ($__process -ne 0) {
+	if ($___process -ne 0) {
+		$null = I18N-Create-Failed
 		return 1
 	}
 
 
 	# NOTE: REQUIRED file
-	OS-Print-Status info "creating man pages file..."
-	$__process = MANUAL-Create `
+	$null = I18N-Create "MAN PAGES"
+	$___process = MANUAL-Create `
 		"${_directory}\BUILD\${env:PROJECT_SKU}.1" `
 		${env:PROJECT_SKU} `
 		${env:PROJECT_CONTACT_NAME} `
 		${env:PROJECT_CONTACT_EMAIL} `
 		${env:PROJECT_CONTACT_WEBSITE}
-	if ($__process -ne 0) {
+	if ($___process -ne 0) {
+		$null = I18N-Create-Failed
 		return 1
 	}
 
 
 	# NOTE: OPTIONAL (Comment to turn it off)
-	OS-Print-Status info "creating source.repo files..."
-	$__process = RPM-Create-Source-Repo `
+	$null = I18N-Create "source.repo"
+	$___process = RPM-Create-Source-Repo `
 		"${env:PROJECT_SIMULATE_RELEASE_REPO}" `
 		"${_directory}" `
 		"${env:PROJECT_GPG_ID}" `
@@ -190,14 +205,15 @@ install -m 644 ${env:PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
 		"${env:PROJECT_REPREPRO_CODENAME}" `
 		"${env:PROJECT_DEBIAN_DISTRIBUTION}" `
 		"${_gpg_keyring}"
-	if ($__process -ne 0) {
+	if ($___process -ne 0) {
+		$null = I18N-Create-Failed
 		return 1
 	}
 
 
 	# WARNING: THIS REQUIRED FILE MUST BE THE LAST ONE
-	OS-Print-Status info "creating spec file..."
-	RPM-Create-Spec `
+	$null = I18N-Create "spec"
+	$___process = RPM-Create-Spec `
 		"${_directory}" `
 		"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}" `
 		"${_package}" `
@@ -209,7 +225,8 @@ install -m 644 ${env:PROJECT_SKU}.1.gz %{buildroot}/usr/local/share/man/man1/
 		"${env:PROJECT_CONTACT_WEBSITE}" `
 		"${env:PROJECT_LICENSE}" `
 		"${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_RESOURCES}\docs\ABSTRACTS.txt"
-	if ($__process -ne 0) {
+	if ($___process -ne 0) {
+		$null = I18N-Create-Failed
 		return 1
 	}
 


### PR DESCRIPTION
The _package-rpm CI job inside src/ directory is outdated and not ready for the latest i18n implementations. Hence, let's refactor it.

This patch refactors _package-rpm CI job for i18n and latest specs compliances in src/ directory.