### PR TITLE
src: refactored _package-flatpak CI job for i18n and latest specs

### DIFF
--- a/automataCI/_package-flatpak_unix-any.sh
+++ b/automataCI/_package-flatpak_unix-any.sh
@@ -90,7 +90,7 @@ PACKAGE_Run_FLATPAK() {
 
 
         # copy all complimentary files to the workspace
-        cmd="PACKAGE_Assemble_Flatpak_Content"
+        cmd="PACKAGE_Assemble_FLATPAK_Content"
         I18N_Check_Function "$cmd"
         OS_Is_Command_Available "$cmd"
         if [ $? -ne 0 ]; then

--- a/src/.ci/_package-flatpak_unix-any.sh
+++ b/src/.ci/_package-flatpak_unix-any.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,18 +15,19 @@
 
 
 # initialize
-if [ "$PROJECT_PATH_ROOT" == "" ]; then
-        >&2 printf "[ ERROR ] - Please run from ci.cmd instead!\n"
+if [ "$PROJECT_PATH_ROOT" = "" ]; then
+        >&2 printf "[ ERROR ] - Please run from automataCI/ci.sh.ps1 instead!\n"
         return 1
 fi
 
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/os.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
 
 
 
 
-PACKAGE_Assemble_Flatpak_Content() {
+PACKAGE_Assemble_FLATPAK_Content() {
         _target="$1"
         _directory="$2"
         _target_name="$3"
@@ -69,9 +70,10 @@ PACKAGE_Assemble_Flatpak_Content() {
         # copy main program
         _target="$1"
         _filepath="${_directory}/${PROJECT_SKU}"
-        OS_Print_Status info "copying ${_target} to ${_filepath}\n"
+        I18N_Copy "$_target" "$_filepath"
         FS_Copy_File "$_target" "$_filepath"
         if [ $? -ne 0 ]; then
+                I18N_Copy_Failed
                 return 1
         fi
 
@@ -79,9 +81,10 @@ PACKAGE_Assemble_Flatpak_Content() {
         # copy icon.svg
         _target="${PROJECT_PATH_ROOT}/${PROJECT_PATH_SOURCE}/icons/icon.svg"
         _filepath="${_directory}/icon.svg"
-        OS_Print_Status info "copying ${_target} to ${_filepath}\n"
+        I18N_Copy "$_target" "$_filepath"
         FS_Copy_File "$_target" "$_filepath"
         if [ $? -ne 0 ]; then
+                I18N_Copy_Failed
                 return 1
         fi
 
@@ -89,9 +92,10 @@ PACKAGE_Assemble_Flatpak_Content() {
         # copy icon-48x48.png
         _target="${PROJECT_PATH_ROOT}/${PROJECT_PATH_SOURCE}/icons/icon-48x48.png"
         _filepath="${_directory}/icon-48x48.png"
-        OS_Print_Status info "copying ${_target} to ${_filepath}\n"
+        I18N_Copy "$_target" "$_filepath"
         FS_Copy_File "$_target" "$_filepath"
         if [ $? -ne 0 ]; then
+                I18N_Copy_Failed
                 return 1
         fi
 
@@ -99,15 +103,18 @@ PACKAGE_Assemble_Flatpak_Content() {
         # copy icon-128x128.png
         _target="${PROJECT_PATH_ROOT}/${PROJECT_PATH_SOURCE}/icons/icon-128x128.png"
         _filepath="${_directory}/icon-128x128.png"
-        OS_Print_Status info "copying ${_target} to ${_filepath}\n"
+        I18N_Copy "$_target" "$_filepath"
         FS_Copy_File "$_target" "$_filepath"
         if [ $? -ne 0 ]; then
+                I18N_Copy_Failed
                 return 1
         fi
 
 
         # [ COMPULSORY ] script manifest.yml
-        FS_Write_File "${_directory}/manifest.yml" "\
+        __file="${_directory}/manifest.yml"
+        I18N_Create "$__file"
+        FS_Write_File "$__file" "\
 app-id: ${PROJECT_APP_ID}
 branch: ${_target_arch}
 default-branch: any
@@ -158,12 +165,15 @@ modules:
         path: icon-128x128.png
 "
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 
 
         # [ COMPULSORY ] script appdata.xml
-        FS_Write_File "${_directory}/appdata.xml" "\
+        __file="${_directory}/appdata.xml"
+        I18N_Create "$__file"
+        FS_Write_File "$__file" "\
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- refer: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
 <component>
@@ -199,6 +209,7 @@ modules:
 </component>
 "
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 

--- a/src/.ci/_package-flatpak_windows-any.ps1
+++ b/src/.ci/_package-flatpak_windows-any.ps1
@@ -1,4 +1,4 @@
-# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy
@@ -15,12 +15,13 @@
 
 # initialize
 if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
-	Write-Error "[ ERROR ] - Please run from ci.cmd instead!`n"
+	Write-Error "[ ERROR ] - Please run from automataCI\ci.sh.ps1 instead!`n"
 	return 1
 }
 
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\os.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\os.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\i18n\translations.ps1"
 
 
 
@@ -68,9 +69,10 @@ function PACKAGE-Assemble-FLATPAK-Content {
 
 	# copy main program
 	$_filepath = "${_directory}\${env:PROJECT_SKU}"
-	OS-Print-Status info "copying ${_target} to ${_filepath}"
-	$__process = FS-Copy-File "${_target}" "${_filepath}"
-	if ($__process -ne 0) {
+	$null = I18N-Copy "${_target}" "${_filepath}"
+	$___process = FS-Copy-File "${_target}" "${_filepath}"
+	if ($___process -ne 0) {
+		$null = I18N-Copy-Failed
 		return 1
 	}
 
@@ -79,9 +81,10 @@ function PACKAGE-Assemble-FLATPAK-Content {
 	$_target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_SOURCE}"
 	$_target = "${_target}\icons\icon.svg"
 	$_filepath = "${_directory}\icon.svg"
-	OS-Print-Status info "copying ${_target} to ${_filepath}"
-	$__process = FS-Copy-File "${_target}" "${_filepath}"
-	if ($__process -ne 0) {
+	$null = I18N-Copy "${_target}" "${_filepath}"
+	$___process = FS-Copy-File "${_target}" "${_filepath}"
+	if ($___process -ne 0) {
+		$null = I18N-Copy-Failed
 		return 1
 	}
 
@@ -90,9 +93,10 @@ function PACKAGE-Assemble-FLATPAK-Content {
 	$_target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_SOURCE}"
 	$_target = "${_target}\icons\icon-48x48.png"
 	$_filepath = "${_directory}\icon-48x48.png"
-	OS-Print-Status info "copying ${_target} to ${_filepath}"
-	$__process = FS-Copy-File "${_target}" "${_filepath}"
-	if ($__process -ne 0) {
+	$null = I18N-Copy "${_target}" "${_filepath}"
+	$___process = FS-Copy-File "${_target}" "${_filepath}"
+	if ($___process -ne 0) {
+		$null = I18N-Copy-Failed
 		return 1
 	}
 
@@ -101,15 +105,18 @@ function PACKAGE-Assemble-FLATPAK-Content {
 	$_target = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_SOURCE}"
 	$_target = "${_target}\icons\icon-128x128.png"
 	$_filepath = "${_directory}\icon-128x128.png"
-	OS-Print-Status info "copying ${_target} to ${_filepath}"
-	$__process = FS-Copy-File "${_target}" "${_filepath}"
-	if ($__process -ne 0) {
+	$null = I18N-Copy "${_target}" "${_filepath}"
+	$___process = FS-Copy-File "${_target}" "${_filepath}"
+	if ($___process -ne 0) {
+		$null = I18N-Copy-Failed
 		return 1
 	}
 
 
 	# [ COMPULSORY ] script manifest.yml
-	$___process = FS-Write-File "${_directory}\manifest.yml" @"
+	$__file = "${_directory}\manifest.yml"
+	$null = I18N-Create "${__file}"
+	$___process = FS-Write-File "${__file}" @"
 app-id: ${env:PROJECT_APP_ID}
 branch: ${_target_arch}
 default-branch: any
@@ -160,12 +167,15 @@ modules:
         path: icon-128x128.png
 "@
 	if ($___process -ne 0) {
+		$null = I18N-Create-Failed
 		return 1
 	}
 
 
 	# [ COMPULSORY ] script appdata.xml
-	$___process = FS-Write-File "${_directory}/appdata.xml" "\
+	$__file = "${_directory}\appdata.xml"
+	$null = I18N-Create "${__file}"
+	$___process = FS-Write-File "${__file}" @"
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- refer: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
 <component>
@@ -199,8 +209,9 @@ modules:
 		<binary>${env:PROJECT_SKU}</binary>
 	</provides>
 </component>
-"
+"@
 	if ($___process -ne 0) {
+		$null = I18N-Create-Failed
 		return 1
 	}
 


### PR DESCRIPTION
The _package-flatpak CI job inside src/ directory is outdated and not ready for the latest i18n implementations. Hence, let's refactor it.

This patch refactors _package-flatpak CI job for i18n and latest specs compliances in src/ directory.