### PR TITLE
src: refactored _package-docker CI job for i18n and latest specs

### DIFF
--- a/automataCI/_package-docker_unix-any.sh
+++ b/automataCI/_package-docker_unix-any.sh
@@ -89,7 +89,7 @@ PACKAGE_Run_DOCKER() {
 
 
         # copy all complimentary files to the workspace
-        cmd="PACKAGE::assemble_docker_content"
+        cmd="PACKAGE_Assemble_DOCKER_Content"
         I18N_Check_Function "$cmd"
         OS_Is_Command_Available "$cmd"
         if [ $? -ne 0 ]; then

--- a/src/.ci/_package-docker_unix-any.sh
+++ b/src/.ci/_package-docker_unix-any.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,18 +15,18 @@
 
 
 # initialize
-if [ "$PROJECT_PATH_ROOT" == "" ]; then
-        >&2 printf "[ ERROR ] - Please run from ci.cmd instead!\n"
+if [ "$PROJECT_PATH_ROOT" = "" ]; then
+        >&2 printf "[ ERROR ] - Please run from automataCI/ci.sh.ps1 instead!\n"
         return 1
 fi
 
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/strings.sh"
 
 
 
 
-PACKAGE::assemble_docker_content() {
+PACKAGE_Assemble_DOCKER_Content() {
         _target="$1"
         _directory="$2"
         _target_name="$3"
@@ -99,13 +99,13 @@ LABEL org.opencontainers.image.revision=\"${PROJECT_CADENCE}\"
 LABEL org.opencontainers.image.licenses=\"${PROJECT_LICENSE}\"
 "
 
-        if [ ! -z "$PROJECT_CONTACT_WEBSITE" ]; then
+        if [ $(STRINGS_Is_Empty "$PROJECT_CONTACT_WEBSITE") -ne 0 ]; then
                 FS_Append_File "${_directory}/Dockerfile" "\
 LABEL org.opencontainers.image.url=\"${PROJECT_CONTACT_WEBSITE}\"
 "
         fi
 
-        if [ ! -z "$PROJECT_SOURCE_URL" ]; then
+        if [ $(STRINGS_Is_Empty "$PROJECT_SOURCE_URL") -ne 0 ]; then
                 FS_Append_File "${_directory}/Dockerfile" "\
 LABEL org.opencontainers.image.source=\"${PROJECT_SOURCE_URL}\"
 "

--- a/src/.ci/_package-docker_windows-any.ps1
+++ b/src/.ci/_package-docker_windows-any.ps1
@@ -1,4 +1,4 @@
-# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy
@@ -15,12 +15,12 @@
 
 # initialize
 if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
-	Write-Error "[ ERROR ] - Please run from ci.cmd instead!\n"
+	Write-Error "[ ERROR ] - Please run from automataCI\ci.sh.ps1 instead!`n"
 	exit 1
 }
 
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\os.ps1"
-. "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_AUTOMATA}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
 
 
 
@@ -65,32 +65,32 @@ function PACKAGE-Assemble-DOCKER-Content {
 
 
 	# assemble the package
-	$__process = FS-Copy-File "${_target}" "${_directory}\${env:PROJECT_SKU}"
-	if ($__process -ne 0) {
+	$___process = FS-Copy-File "${_target}" "${_directory}\${env:PROJECT_SKU}"
+	if ($___process -ne 0) {
 		return 1
 	}
 
-	$__process = FS-Touch-File "${_directory}\.blank"
-	if ($__process -ne 0) {
+	$___process = FS-Touch-File "${_directory}\.blank"
+	if ($___process -ne 0) {
 		return 1
 	}
 
 
 	# generate the Dockerfile
-	$__process = FS-Write-File "${_directory}\Dockerfile" @"
+	$___process = FS-Write-File "${_directory}\Dockerfile" @"
 # Defining baseline image
 "@
 	if (${_target_os} == "windows") {
-		$__process = FS-Append-File "${_directory}\Dockerfile" @"
+		$___process = FS-Append-File "${_directory}\Dockerfile" @"
 FROM --platform=${_target_os}/${_target_arch} mcr.microsoft.com/windows/nanoserver:ltsc2022
 "@
 	} else {
-		$__process = FS-Append-File "${_directory}\Dockerfile" @"
+		$___process = FS-Append-File "${_directory}\Dockerfile" @"
 FROM --platform=${_target_os}/${_target_arch} busybox:latest
 "@
 	}
 
-	$__process = FS-Append-File "${_directory}\Dockerfile" @"
+	$___process = FS-Append-File "${_directory}\Dockerfile" @"
 LABEL org.opencontainers.image.title=`"${env:PROJECT_NAME}`"
 LABEL org.opencontainers.image.description=`"${env:PROJECT_PITCH}`"
 LABEL org.opencontainers.image.authors=`"${env:PROJECT_CONTACT_NAME} <${env:PROJECT_CONTACT_EMAIL}>`"
@@ -99,19 +99,19 @@ LABEL org.opencontainers.image.revision=`"${env:PROJECT_CADENCE}`"
 LABEL org.opencontainers.image.licenses=`"${env:PROJECT_LICENSE}`"
 "@
 
-	if (-not ([string]::IsNullOrEmpty(${env:PROJECT_CONTACT_WEBSITE}))) {
-		$__process = FS-Append-File "${_directory}\Dockerfile" @"
+	if ($(STRINGS-Is-Empty "${env:PROJECT_CONTACT_WEBSITE}") -ne 0) {
+		$___process = FS-Append-File "${_directory}\Dockerfile" @"
 LABEL org.opencontainers.image.url=`"${env:PROJECT_CONTACT_WEBSITE}`"
 "@
 	}
 
-	if (-not ([string]::IsNullOrEmpty(${env:PROJECT_SOURCE_URL}))) {
-		$__process = FS-Append-File "${_directory}\Dockerfile" @"
+	if ($(STRINGS-Is-Empty "${env:PROJECT_SOURCE_URL}") -ne 0) {
+		$___process = FS-Append-File "${_directory}\Dockerfile" @"
 LABEL org.opencontainers.image.source=`"${env:PROJECT_SOURCE_URL}`"
 "@
 	}
 
-	$__process = FS-Append-File "${_directory}\Dockerfile" @"
+	$___process = FS-Append-File "${_directory}\Dockerfile" @"
 # Defining environment variables
 ENV ARCH ${_target_arch}
 ENV OS ${_target_os}
@@ -127,7 +127,7 @@ EXPOSE 80
 # Set entry point
 ENTRYPOINT ["/app/bin/${PROJECT_SKU}"]
 "@
-	if ($__process -ne 0) {
+	if ($___process -ne 0) {
 		return 1
 	}
 

--- a/srcC/.ci/_package-docker_unix-any.sh
+++ b/srcC/.ci/_package-docker_unix-any.sh
@@ -26,7 +26,7 @@ fi
 
 
 
-PACKAGE::assemble_docker_content() {
+PACKAGE_Assemble_DOCKER_Content() {
         _target="$1"
         _directory="$2"
         _target_name="$3"

--- a/srcGO/.ci/_package-docker_unix-any.sh
+++ b/srcGO/.ci/_package-docker_unix-any.sh
@@ -26,7 +26,7 @@ fi
 
 
 
-PACKAGE::assemble_docker_content() {
+PACKAGE_Assemble_DOCKER_Content() {
         _target="$1"
         _directory="$2"
         _target_name="$3"

--- a/srcPYTHON/.ci/_package-docker_unix-any.sh
+++ b/srcPYTHON/.ci/_package-docker_unix-any.sh
@@ -26,7 +26,7 @@ fi
 
 
 
-PACKAGE::assemble_docker_content() {
+PACKAGE_Assemble_DOCKER_Content() {
         _target="$1"
         _directory="$2"
         _target_name="$3"

--- a/srcRUST/.ci/_package-docker_unix-any.sh
+++ b/srcRUST/.ci/_package-docker_unix-any.sh
@@ -26,7 +26,7 @@ fi
 
 
 
-PACKAGE::assemble_docker_content() {
+PACKAGE_Assemble_DOCKER_Content() {
         _target="$1"
         _directory="$2"
         _target_name="$3"


### PR DESCRIPTION
The _package-docker CI job inside src/ directory is outdated and not ready for the latest i18n implementations. Hence, let's refactor it.

This patch refactors _package-docker CI job for i18n and latest specs compliances in src/ directory.