### PR TITLE
src: refactored _package-deb CI job for i18n and latest specs

### DIFF
--- a/src/.ci/_package-deb_unix-any.sh
+++ b/src/.ci/_package-deb_unix-any.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2023  (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
+# Copyright 2023 (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -15,16 +15,16 @@
 
 
 # initialize
-if [ "$PROJECT_PATH_ROOT" == "" ]; then
-        >&2 printf "[ ERROR ] - Please run from ci.cmd instead!\n"
+if [ "$PROJECT_PATH_ROOT" = "" ]; then
+        >&2 printf "[ ERROR ] - Please run from autoamtaCI/ci.sh.ps1 instead!\n"
         return 1
 fi
 
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/os.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/io/fs.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/copyright.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/deb.sh"
-. "${PROJECT_PATH_ROOT}/${PROJECT_PATH_AUTOMATA}/services/compilers/manual.sh"
+. "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
+. "${LIBS_AUTOMATACI}/services/compilers/copyright.sh"
+. "${LIBS_AUTOMATACI}/services/compilers/deb.sh"
+. "${LIBS_AUTOMATACI}/services/compilers/manual.sh"
 
 
 
@@ -70,14 +70,16 @@ PACKAGE_Assemble_DEB_Content() {
                 #      (2) please avoid: lib/, lib{TYPE}/ usr/lib/, and usr/lib{TYPE}/
                 _filepath="${_directory}/data/usr/local/lib/${PROJECT_SKU}"
                 _filepath="${_filepath}/lib${PROJECT_SKU}.a"
-                OS_Print_Status info "copying ${_target} to ${_filepath}\n"
+                I18N_Copy "$_target" "$_filepath"
                 FS_Make_Housing_Directory "$_filepath"
                 if [ $? -ne 0 ]; then
+                        I18N_Copy_Failed
                         return 1
                 fi
 
                 FS_Copy_File "$_target" "$_filepath"
                 if [ $? -ne 0 ]; then
+                        I18N_Copy_Failed
                         return 1
                 fi
 
@@ -101,21 +103,23 @@ PACKAGE_Assemble_DEB_Content() {
                 #      (2) please avoid: bin/, usr/bin/, sbin/, and usr/sbin/
                 _filepath="${_directory}/data/usr/local/bin/${PROJECT_SKU}"
 
-                OS_Print_Status info "copying $_target to ${_filepath}/\n"
+                I18N_Copy "$_target" "$_filepath"
                 FS_Make_Housing_Directory "$_filepath"
                 if [ $? -ne 0 ]; then
+                        I18N_Copy_Failed
                         return 1
                 fi
 
                 FS_Copy_File "$_target" "$_filepath"
                 if [ $? -ne 0 ]; then
+                        I18N_Copy_Failed
                         return 1
                 fi
         fi
 
 
         # NOTE: REQUIRED file
-        OS_Print_Status info "creating changelog.gz files...\n"
+        I18N_Create "changelog.gz"
         _changelog_path="${_directory}/data/usr/local/share/doc/${PROJECT_SKU}/changelog.gz"
         if [ "$PROJECT_DEBIAN_IS_NATIVE" = "true" ]; then
                 _changelog_path="${_directory}/data/usr/share/doc/${PROJECT_SKU}/changelog.gz"
@@ -123,12 +127,13 @@ PACKAGE_Assemble_DEB_Content() {
 
         DEB_Create_Changelog "$_changelog_path" "$_changelog" "$PROJECT_SKU"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 
 
         # NOTE: REQUIRED file
-        OS_Print_Status info "creating copyright.gz file...\n"
+        I18N_Create "copyright.gz"
         _copyright="${_directory}/data/usr/local/share/doc/${PROJECT_SKU}/copyright"
         if [ "$PROJECT_DEBIAN_IS_NATIVE" = "true" ]; then
                 _copyright="${_directory}/data/usr/share/doc/${PROJECT_SKU}/copyright"
@@ -142,12 +147,13 @@ PACKAGE_Assemble_DEB_Content() {
                 "$PROJECT_CONTACT_EMAIL" \
                 "$PROJECT_CONTACT_WEBSITE"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 
 
         # NOTE: REQUIRED file
-        OS_Print_Status info "creating man(page) files...\n"
+        I18N_Create "MANPAGE"
         _manual="${_directory}/data/usr/local/share/man/man1/${PROJECT_SKU}.1"
         if [ "$PROJECT_DEBIAN_IS_NATIVE" = "true" ]; then
                 _manual="${_directory}/data/usr/share/man/man1/${PROJECT_SKU}.1"
@@ -160,20 +166,22 @@ PACKAGE_Assemble_DEB_Content() {
                 "$PROJECT_CONTACT_EMAIL" \
                 "$PROJECT_CONTACT_WEBSITE"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 
 
         # NOTE: REQUIRED file
-        OS_Print_Status info "creating control/md5sum files...\n"
+        I18N_Create "control/md5sum"
         DEB_Create_Checksum "$_directory"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 
 
         # NOTE: OPTIONAL (Comment to turn it off)
-        OS_Print_Status info "creating source.list files...\n"
+        I18N_Create "source.list"
         DEB_Create_Source_List \
                 "$PROJECT_SIMULATE_RELEASE_REPO" \
                 "$_directory" \
@@ -183,12 +191,13 @@ PACKAGE_Assemble_DEB_Content() {
                 "$PROJECT_DEBIAN_DISTRIBUTION" \
                 "$_gpg_keyring"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 
 
         # WARNING: THIS REQUIRED FILE MUST BE THE LAST ONE
-        OS_Print_Status info "creating control/control file...\n"
+        I18N_Create "control/control"
         DEB_Create_Control \
                 "$_directory" \
                 "${PROJECT_PATH_ROOT}/${PROJECT_PATH_SOURCE}" \
@@ -204,6 +213,7 @@ PACKAGE_Assemble_DEB_Content() {
                 "$PROJECT_DEBIAN_SECTION" \
                 "${PROJECT_PATH_ROOT}/${PROJECT_PATH_SOURCE}/docs/ABSTRACTS.txt"
         if [ $? -ne 0 ]; then
+                I18N_Create_Failed
                 return 1
         fi
 


### PR DESCRIPTION
The _package-deb CI job inside src/ directory is oudated and not ready for the latest i18n implementations. Hence, let's refactor it.

This patch refactors _package-deb CI job for i18n and latest specs compliances in src/ directory.