### PR TITLE
srcGO: backported enhanced changes for build recipe

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -284,7 +284,7 @@ PROJECT_PATH_NUPKG = "nupkg"
 #
 # To enable it: simply supply the path (e.g. default is 'srcGO').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_GO = ''
+PROJECT_GO = 'srcGO'
 
 
 # PROJECT_PATH_GO_ENGINE
@@ -306,7 +306,7 @@ PROJECT_PATH_GO_ENGINE = "go-engine"
 #
 # To enable it: simply supply the path (e.g. default is 'srcNIM').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_NIM = 'srcNIM'
+PROJECT_NIM = ''
 
 
 # PROJECT_PATH_NIM_ENGINE

--- a/srcGO/.ci/build_unix-any.sh
+++ b/srcGO/.ci/build_unix-any.sh
@@ -114,8 +114,15 @@ done
 # placeholding flag files
 old_IFS="$IFS"
 while IFS="" read -r __line || [ -n "$__line" ]; do
+        if [ $(STRINGS_Is_Empty "$__line") -eq 0 ]; then
+                continue
+        fi
+
+
+        # build the file
         __file="${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}/${__line}"
-        I18N_Build "$__file"
+        I18N_Build "$__line"
+        FS_Remove_Silently "$__file"
         FS_Touch_File "$__file"
         if [ $? -ne 0 ]; then
                 I18N_Build_Failed

--- a/srcGO/.ci/build_windows-any.ps1
+++ b/srcGO/.ci/build_windows-any.ps1
@@ -114,8 +114,15 @@ $null = Remove-Variable -Name __go_arch
 
 # placeholding flag files
 foreach ($__line in $__placeholders) {
+	if ($(STRINGS-Is-Empty "${__line}") -eq 0) {
+		continue
+	}
+
+
+	# build the file
 	$__file = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BUILD}\${__line}"
-	$null = I18N-Build "${__file}"
+	$null = I18N-Build "${__line}"
+	$null = FS-Remove-Silently "${__file}"
 	$___process = FS-Touch-File "${__file}"
 	if ($___process -ne 0) {
 		$null = I18N-Build-Failed

--- a/srcGO/.ci/materialize_unix-any.sh
+++ b/srcGO/.ci/materialize_unix-any.sh
@@ -65,6 +65,9 @@ fi
 
 ___source="${__output_directory}/${__filename}"
 ___dest="${PROJECT_PATH_ROOT}/${PROJECT_PATH_BIN}/${PROJECT_SKU}"
+if [ "$PROJECT_OS" = "windows" ]; then
+        ___dest="${___dest}.exe"
+fi
 I18N_Export "$___source" "$___dest"
 FS_Make_Housing_Directory "$___dest"
 FS_Remove_Silently "$___dest"

--- a/srcGO/.ci/materialize_windows-any.ps1
+++ b/srcGO/.ci/materialize_windows-any.ps1
@@ -82,7 +82,10 @@ if ($___process -ne 0) {
 
 
 $___source = "${__output_directory}\${__filename}"
-$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BIN}\${env:PROJECT_SKU}.exe"
+$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BIN}\${env:PROJECT_SKU}"
+if ("${env:PROJECT_OS}" -eq "windows") {
+	$___dest = "${___dest}.exe"
+}
 $null = I18N-Export "${___source}" "${___dest}"
 $null = FS-Make-Housing-Directory "${___dest}"
 $null = FS-Remove-Silently "${___dest}"


### PR DESCRIPTION
It appeared the build recipe in srcNIM/ directory is enhanced with proper guard rails. Hence, let's backport it to srcGO/ directory.

This patch backports enhanced changes for build recipes into srcGO/ directory.