### PR TITLE
srcPYTHON: backported enhanced changes from srcNIM

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -284,7 +284,7 @@ PROJECT_PATH_NUPKG = "nupkg"
 #
 # To enable it: simply supply the path (e.g. default is 'srcGO').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_GO = 'srcGO'
+PROJECT_GO = ''
 
 
 # PROJECT_PATH_GO_ENGINE
@@ -329,7 +329,7 @@ PROJECT_PATH_NIM_ENGINE = "nim-engine"
 #
 # To enable it: simply supply the path (e.g. default is 'srcPYTHON').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_PYTHON = ''
+PROJECT_PYTHON = 'srcPYTHON'
 
 
 # PROJECT_PATH_PYTHON_ENGINE

--- a/srcPYTHON/.ci/build_unix-any.sh
+++ b/srcPYTHON/.ci/build_unix-any.sh
@@ -95,8 +95,15 @@ fi
 # placeholding flag files
 old_IFS="$IFS"
 while IFS="" read -r __line || [ -n "$__line" ]; do
+        if [ $(STRINGS_Is_Empty "$__line") -eq 0 ]; then
+                continue
+        fi
+
+
+        # build the file
         __file="${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}/${__line}"
-        I18N_Build "$__file"
+        I18N_Build "$__line"
+        FS_Remove_Silently "$__file"
         FS_Touch_File "$__file"
         if [ $? -ne 0 ]; then
                 I18N_Build_Failed

--- a/srcPYTHON/.ci/build_windows-any.ps1
+++ b/srcPYTHON/.ci/build_windows-any.ps1
@@ -90,8 +90,15 @@ if ($___process -ne 0) {
 
 # placeholding flag files
 foreach ($__line in $__placeholders) {
+	if ($(STRINGS-Is-Empty "${__line}") -eq 0) {
+		continue
+	}
+
+
+	# build the file
 	$__file = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BUILD}\${__line}"
-	$null = I18N-Build "${__file}"
+	$null = I18N-Build "${__line}"
+	$null = FS-Remove-Silently "${__file}"
 	$___process = FS-Touch-File "${__file}"
 	if ($___process -ne 0) {
 		$null = I18N-Build-Failed

--- a/srcPYTHON/.ci/materialize_unix-any.sh
+++ b/srcPYTHON/.ci/materialize_unix-any.sh
@@ -86,6 +86,9 @@ fi
 # shipping executable
 __source="${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}/${__source}"
 __dest="${PROJECT_PATH_ROOT}/${PROJECT_PATH_BIN}/${PROJECT_SKU}"
+if [ "$PROJECT_OS" = "windows" ]; then
+        __dest="${__dest}.exe"
+fi
 I18N_Export "$__source" "$__dest"
 FS_Make_Housing_Directory "$__dest"
 FS_Remove_Silently "$__dest"

--- a/srcPYTHON/.ci/materialize_windows-any.ps1
+++ b/srcPYTHON/.ci/materialize_windows-any.ps1
@@ -83,7 +83,10 @@ if ($___process -ne 0) {
 
 # exporting executable
 $__source = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BUILD}\${__source}"
-$__dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BIN}\${env:PROJECT_SKU}.exe"
+$__dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BIN}\${env:PROJECT_SKU}"
+if ("${env:PROJECT_OS}" -eq "windows") {
+	$__dest = "${__dest}.exe"
+}
 $null = I18N-Export "${__source}" "${__dest}"
 $null = FS-Make-Directory "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BIN}"
 $null = FS-Remove-Silently "${__dest}"


### PR DESCRIPTION
It appears the CI job recipes in srcNIM/ directory are enhanced with proper guard rails. Hence, let's backport it to srcPYTHON/ directory.

This patch backports enhanced changes for all CI recipes into srcPYTHON/ directory.