### PR TITLE
.github: removed checkout dependency from GitHub Actions

### DIFF
--- a/.github/workflows/git-push.yml
+++ b/.github/workflows/git-push.yml
@@ -19,6 +19,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
         TERM: xterm-256color
+        ROBOT_NAME: "github.actions.runner@github.com"
+        ROBOT_EMAIL: "Github Actions Autonomous Runner System"
+        REPO_NAME: ${{ github.event.repository.name }}
+        REPO_URL: "${{ github.server_url  }}/${{ github.repository }}"
+        REPO_COMMIT: "${{ github.sha }}"
         CONTAINER_USERNAME: ${{ secrets.CONTAINER_USERNAME }}
         CONTAINER_PASSWORD: ${{ secrets.CONTAINER_PASSWORD }}
         TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
@@ -26,14 +31,15 @@ jobs:
         PROJECT_SIMULATE_RELEASE_REPO: true
         PROJECT_ROBOT_RUN: true
     steps:
-      - name: GITHUB ACTIONS - CHECKOUT
-        id: git_check_out
-        uses: actions/checkout@v4
-      - name: GIT - INIT
-        id: git_initialize
+      - name: Git - INIT
+        id: git_init
         run: |
-          git config --global user.email "github.actions.runner@github.com"
-          git config --global user.name "Github Actions Automated Runner System"
+          git config --global user.email "${{ env.ROBOT_NAME }}"
+          git config --global user.name "${{ env.ROBOT_EMAIL }}"
+          git config --global advice.detachedHead false
+          git clone --depth=1 ${{ env.REPO_URL }} .
+          git fetch origin ${{ env.REPO_COMMIT }}
+          git checkout FETCH_HEAD
       - name: AutomataCI - PURGE
         id: automataci_ci_purge
         run: |


### PR DESCRIPTION
Right now, we're depending on Checkout Actions from GitHub Actions marketplace for simple git checkout. Hence, let's try to remove it.

This patch removes checkout dependency from GitHub Actions in .github/ directory.