### PR TITLE
automataCI: fixed a typo causing the docker packager failed

### DIFF
--- a/automataCI/_package-docker_unix-any.sh
+++ b/automataCI/_package-docker_unix-any.sh
@@ -67,7 +67,7 @@ PACKAGE_Run_DOCKER() {
                 ;;
         esac
 
-        I18N_Check_login "DOCKER"
+        I18N_Check_Login "DOCKER"
         DOCKER_Check_Login
         if [ $? -ne 0 ]; then
                 I18N_Check_Failed


### PR DESCRIPTION
It appears there was a typo in the docker packager recipe causing the packager failed dramatically. Hence, let's fix it.

This patch fixes a typo causing the docker packager to fail in automataCI/ directory.