### PR TITLE
srcRUST: backported enhanced changes from srcNIM

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -329,7 +329,7 @@ PROJECT_PATH_NIM_ENGINE = "nim-engine"
 #
 # To enable it: simply supply the path (e.g. default is 'srcPYTHON').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_PYTHON = 'srcPYTHON'
+PROJECT_PYTHON = ''
 
 
 # PROJECT_PATH_PYTHON_ENGINE
@@ -370,7 +370,7 @@ PROJECT_PYPI_README_MIME = "text/markdown"
 #
 # To enable it: simply supply the path (e.g. default is 'srcRUST').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_RUST = ''
+PROJECT_RUST = 'srcRUST'
 
 
 # PROJECT_RUST_EDITION

--- a/srcRUST/.ci/build_unix-any.sh
+++ b/srcRUST/.ci/build_unix-any.sh
@@ -189,6 +189,10 @@ SUBROUTINE_Build() {
 old_IFS="$IFS"
 while IFS="" read -r __line || [ -n "$__line" ]; do
         # parse target data
+        if [ $(STRINGS_Is_Empty "$__line") -eq 0 ]; then
+                continue
+        fi
+
         __extension="${__line##*|}"
         __line="${__line%|*}"
 
@@ -219,11 +223,31 @@ while IFS="" read -r __line || [ -n "$__line" ]; do
         ## NOTE: perform any hard-coded host system restrictions or gatekeeping
         ##       customization adjustments here.
         case "$__arch" in ### filter by CPU Architecture
-        mips|mipsel|mipsle|mips64|mips64el|mips64le)
+        mips|mipsel|mipsle)
                 I18N_Sync_Register_Skipped_Unsupported
                 continue
                 ;;
-        ppc64|riscv64)
+        mips64)
+                I18N_Sync_Register_Skipped_Unsupported
+                continue
+                ;;
+        mips64el|mips64le)
+                I18N_Sync_Register_Skipped_Unsupported
+                continue
+                ;;
+        ppc64el|ppc64le)
+                I18N_Sync_Register_Skipped_Unsupported
+                continue
+                ;;
+        ppc64)
+                I18N_Sync_Register_Skipped_Unsupported
+                continue
+                ;;
+        riscv64)
+                I18N_Sync_Register_Skipped_Unsupported
+                continue
+                ;;
+        s390x)
                 I18N_Sync_Register_Skipped_Unsupported
                 continue
                 ;;
@@ -286,8 +310,15 @@ fi
 # placeholding flag files
 old_IFS="$IFS"
 while IFS="" read -r __line || [ -n "$__line" ]; do
+        if [ $(STRINGS_Is_Empty "$__line") -eq 0 ]; then
+                continue
+        fi
+
+
+        # build the file
         __file="${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}/${__line}"
-        I18N_Build "$__file"
+        I18N_Build "$__line"
+        FS_Remove_Silently "$__file"
         FS_Touch_File "$__file"
         if [ $? -ne 0 ]; then
                 I18N_Build_Failed

--- a/srcRUST/.ci/build_windows-any.ps1
+++ b/srcRUST/.ci/build_windows-any.ps1
@@ -217,7 +217,25 @@ foreach ($__line in $__build_targets) {
 	## NOTE: perform any hard-coded host system restrictions or gatekeeping
 	##       customization adjustments here.
 	switch ($__arch) { ### filter by CPU Architecture
-	{ $_ -in "ppc64", "riscv64" } {
+	{ $_ -in "mips", "mipsel", "mipsle" } {
+		$null = I18N-Sync-Register-Skipped-Unsupported
+		continue
+	} { $_ -in "mips64" } {
+		$null = I18N-Sync-Register-Skipped-Unsupported
+		continue
+	} { $_ -in "mips64el", "mips64le" } {
+		$null = I18N-Sync-Register-Skipped-Unsupported
+		continue
+	} { $_ -in "ppc64el", "ppc64le" } {
+		$null = I18N-Sync-Register-Skipped-Unsupported
+		continue
+	} { $_ -in "ppc64" } {
+		$null = I18N-Sync-Register-Skipped-Unsupported
+		continue
+	} { $_ -in "riscv64" } {
+		$null = I18N-Sync-Register-Skipped-Unsupported
+		continue
+	} { $_ -in "s390x" } {
 		$null = I18N-Sync-Register-Skipped-Unsupported
 		continue
 	} wasm {
@@ -270,8 +288,15 @@ if ($___process -ne 0) {
 
 # placeholding flag files
 foreach ($__line in $__placeholders) {
+	if ($(STRINGS-Is-Empty "${__line}") -eq 0) {
+		continue
+	}
+
+
+	# build the file
 	$__file = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BUILD}\${__line}"
-	$null = I18N-Build "${__file}"
+	$null = I18N-Build "${__line}"
+	$null = FS-Remove-Silently "${__file}"
 	$___process = FS-Touch-File "${__file}"
 	if ($___process -ne 0) {
 		$null = I18N-Build-Failed

--- a/srcRUST/.ci/materialize_unix-any.sh
+++ b/srcRUST/.ci/materialize_unix-any.sh
@@ -62,6 +62,9 @@ fi
 
 ___source="${__workspace}/${__target}/release/${PROJECT_SKU}"
 ___dest="${PROJECT_PATH_ROOT}/${PROJECT_PATH_BIN}/${PROJECT_SKU}"
+if [ "$PROJECT_OS" = "windows" ]; then
+        ___dest="${___dest}.exe"
+fi
 I18N_Export "$___source" "$___dest"
 FS_Make_Housing_Directory "$___dest"
 FS_Remove_Silently "$___dest"

--- a/srcRUST/.ci/materialize_windows-any.ps1
+++ b/srcRUST/.ci/materialize_windows-any.ps1
@@ -65,7 +65,10 @@ if ($___process -ne 0) {
 
 
 $___source = "${__workspace}\${__target}\release\${env:PROJECT_SKU}.exe"
-$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BIN}\${env:PROJECT_SKU}.exe"
+$___dest = "${env:PROJECT_PATH_ROOT}\${env:PROJECT_PATH_BIN}\${env:PROJECT_SKU}"
+if ("${env:PROJECT_OS}" -eq "windows") {
+	$___dest = "${___dest}.exe"
+}
 $null = I18N-Export "${___source}" "${___dest}"
 $null = FS-Make-Housing-Directory "${___dest}"
 $null = FS-Remove-Silently "${___dest}"


### PR DESCRIPTION
It appears the CI job recipes in srcNIM/ directory are enhanced with proper guard rails. Hence, let's backport it to srcRUST/ directory.

This patch backports enhanced changes for all CI recipes into srcRUST/ directory.