### PR TITLE
srcGO: backported new changes from srcGO/ directory

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -284,7 +284,7 @@ PROJECT_PATH_NUPKG = "nupkg"
 #
 # To enable it: simply supply the path (e.g. default is 'srcGO').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_GO = ''
+PROJECT_GO = 'srcGO'
 
 
 # PROJECT_PATH_GO_ENGINE
@@ -306,7 +306,7 @@ PROJECT_PATH_GO_ENGINE = "go-engine"
 #
 # To enable it: simply supply the path (e.g. default is 'srcNIM').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_NIM = 'srcNIM'
+PROJECT_NIM = ''
 
 
 # PROJECT_PATH_NIM_ENGINE

--- a/srcGO/.ci/_package-archive_unix-any.sh
+++ b/srcGO/.ci/_package-archive_unix-any.sh
@@ -89,17 +89,8 @@ PACKAGE_Assemble_ARCHIVE_Content() {
         elif [ $(FS_Is_Target_A_MSI "$_target") -eq 0 ]; then
                 return 10 # not applicable
         else
-                case "$_target_os" in
-                windows)
-                        _dest="${_directory}/${PROJECT_SKU}.exe"
-                        ;;
-                *)
-                        _dest="${_directory}/${PROJECT_SKU}"
-                        ;;
-                esac
-
-                I18N_Assemble "$_target" "$_dest"
-                FS_Copy_File "$_target" "$_dest"
+                I18N_Assemble "$_target" "$_directory"
+                FS_Copy_File "$_target" "$_directory"
                 if [ $? -ne 0 ]; then
                         I18N_Assemble_Failed
                         return 1

--- a/srcGO/.ci/_package-archive_windows-any.ps1
+++ b/srcGO/.ci/_package-archive_windows-any.ps1
@@ -89,15 +89,8 @@ function PACKAGE-Assemble-ARCHIVE-Content {
 	} elseif ($(FS-Is-Target-A-MSI "${_target}") -eq 0) {
 		return 10 # not applicable
 	} else {
-		switch (${_target_os}) {
-		"windows" {
-			$_dest = "${_directory}\${env:PROJECT_SKU}.exe"
-		} Default {
-			$_dest = "${_directory}\${env:PROJECT_SKU}"
-		}}
-
-		$null = I18N-Assemble "${_target}" "${_dest}"
-		$___process = FS-Copy-File "${_target}" "${_dest}"
+		$null = I18N-Assemble "${_target}" "${_directory}"
+		$___process = FS-Copy-File "${_target}" "${_directory}"
 		if ($___process -ne 0) {
 			$null = I18N-Assemble-Failed
 			return 1

--- a/srcGO/.ci/_package-chocolatey_unix-any.sh
+++ b/srcGO/.ci/_package-chocolatey_unix-any.sh
@@ -238,6 +238,7 @@ Write-Host \"Uninstalling ${PROJECT_SKU} (${PROJECT_VERSION})...\"
         </metadata>
         <dependencies>
                 <dependency id=\"chocolatey\" version=\"0.9.8.21\" />
+                <dependency id=\"go\" version=\"1.22.1\" />
         </dependencies>
         <files>
                 <file src=\"README.md\" target=\"README.md\" />

--- a/srcGO/.ci/_package-chocolatey_windows-any.ps1
+++ b/srcGO/.ci/_package-chocolatey_windows-any.ps1
@@ -238,6 +238,7 @@ Write-Host "Uninstalling ${env:PROJECT_SKU} (${env:PROJECT_VERSION})..."
 	</metadata>
 	<dependencies>
 		<dependency id="chocolatey" version="0.9.8.21" />
+		<dependency id="go" version="1.22.1" />
 	</dependencies>
 	<files>
 		<file src="README.md" target="README.md" />


### PR DESCRIPTION
There were some new changes discovered from srcC/ refactoring effort. Hence, let's backport them.

This patch backports new changes from srcC/ directory into srcGO/ directory.