### PR TITLE
srcRUST: backported new changes from srcC/ directory

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -284,7 +284,7 @@ PROJECT_PATH_NUPKG = "nupkg"
 #
 # To enable it: simply supply the path (e.g. default is 'srcGO').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_GO = 'srcGO'
+PROJECT_GO = ''
 
 
 # PROJECT_PATH_GO_ENGINE
@@ -370,7 +370,7 @@ PROJECT_PYPI_README_MIME = "text/markdown"
 #
 # To enable it: simply supply the path (e.g. default is 'srcRUST').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_RUST = ''
+PROJECT_RUST = 'srcRUST'
 
 
 # PROJECT_RUST_EDITION

--- a/srcRUST/.ci/_package-archive_unix-any.sh
+++ b/srcRUST/.ci/_package-archive_unix-any.sh
@@ -111,17 +111,8 @@ PACKAGE_Assemble_ARCHIVE_Content() {
         elif [ $(FS_Is_Target_A_MSI "$_target") -eq 0 ]; then
                 return 10 # not applicable
         else
-                case "$_target_os" in
-                windows)
-                        _dest="${_directory}/${PROJECT_SKU}.exe"
-                        ;;
-                *)
-                        _dest="${_directory}/${PROJECT_SKU}"
-                        ;;
-                esac
-
-                I18N_Assemble "$_target" "$_dest"
-                FS_Copy_File "$_target" "$_dest"
+                I18N_Assemble "$_target" "$_directory"
+                FS_Copy_File "$_target" "$_directory"
                 if [ $? -ne 0 ]; then
                         I18N_Assemble_Failed
                         return 1

--- a/srcRUST/.ci/_package-archive_windows-any.ps1
+++ b/srcRUST/.ci/_package-archive_windows-any.ps1
@@ -111,15 +111,8 @@ function PACKAGE-Assemble-ARCHIVE-Content {
 	} elseif ($(FS-Is-Target-A-MSI "${_target}") -eq 0) {
 		return 10 # not applicable
 	} else {
-		switch (${_target_os}) {
-		"windows" {
-			$_dest = "${_directory}\${env:PROJECT_SKU}.exe"
-		} Default {
-			$_dest = "${_directory}\${env:PROJECT_SKU}"
-		}}
-
-		$null = I18N-Assemble "${_target}" "${_dest}"
-		$___process = FS-Copy-File "${_target}" "${_dest}"
+		$null = I18N-Assemble "${_target}" "${_directory}"
+		$___process = FS-Copy-File "${_target}" "${_directory}"
 		if ($___process -ne 0) {
 			$null = I18N-Assemble-Failed
 			return 1

--- a/srcRUST/.ci/_package-chocolatey_unix-any.sh
+++ b/srcRUST/.ci/_package-chocolatey_unix-any.sh
@@ -260,6 +260,7 @@ Write-Host \"Uninstalling ${PROJECT_SKU} (${PROJECT_VERSION})...\"
         </metadata>
         <dependencies>
                 <dependency id=\"chocolatey\" version=\"0.9.8.21\" />
+                <dependency id=\"rust\" version=\"1.76.0\" />
         </dependencies>
         <files>
                 <file src=\"README.md\" target=\"README.md\" />

--- a/srcRUST/.ci/_package-chocolatey_windows-any.ps1
+++ b/srcRUST/.ci/_package-chocolatey_windows-any.ps1
@@ -260,6 +260,7 @@ Write-Host "Uninstalling ${env:PROJECT_SKU} (${env:PROJECT_VERSION})..."
 	</metadata>
 	<dependencies>
 		<dependency id="chocolatey" version="0.9.8.21" />
+		<dependency id="rust" version="1.76.0" />
 	</dependencies>
 	<files>
 		<file src="README.md" target="README.md" />


### PR DESCRIPTION
There were some new changes discovered from srcC/ refactoring effort. Hence, let's backport them.

This patch backports new changes from srcC/ directory into srcRUST/ directory.