### PR TITLE
srcANGULAR: applied fix for CVE-2024-29180 security vulenerabiltiy

### DIFF
--- a/CONFIG.toml
+++ b/CONFIG.toml
@@ -171,7 +171,7 @@ AUTOMATACI_LANG = ""
 #
 # To enable it: simply supply the path (e.g. default is 'srcANGULAR').
 # To disable it: simply supply an empty path (e.g. default is '').
-PROJECT_ANGULAR = ''
+PROJECT_ANGULAR = 'srcANGULAR'
 
 
 

--- a/srcANGULAR/package-lock.json
+++ b/srcANGULAR/package-lock.json
@@ -127,7 +127,7 @@
         "vite": "5.1.5",
         "watchpack": "2.4.0",
         "webpack": "5.90.3",
-        "webpack-dev-middleware": "6.1.1",
+        "webpack-dev-middleware": "6.1.2",
         "webpack-dev-server": "4.15.1",
         "webpack-merge": "5.10.0",
         "webpack-subresource-integrity": "5.1.0"
@@ -11970,9 +11970,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.1.tgz",
-      "integrity": "sha512-y51HrHaFeeWir0YO4f0g+9GwZawuigzcAdRNon6jErXy/SqV/+O6eaVAzDqE6t3e3NpGeR5CS+cCDaTC+V3yEQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.2.tgz",
+      "integrity": "sha512-Wu+EHmX326YPYUpQLKmKbTyZZJIB8/n6R09pTmB03kJmnMsVPTo9COzHZFr01txwaCAuZvfBJE4ZCHRcKs5JaQ==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",
@@ -12057,9 +12057,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",


### PR DESCRIPTION
While not directly involved and used, the Angular sample inside srcANGULAR/ directory contains a security vulnerability CVE-2024-29180 from one if Angular's depedency with high severity (7.4/10). The problem is mainly because the middleware is able to perform path traversal and eventually obtain sensitive files like /etc/passwd using simple command like:
 $ curl localhost:8080/public/..%2f..%2f..%2f..%2f../etc/passwd

Hence, we need to amend it and roll out a hot release.

This patch applies CVE-2024-29180 fixes in srcANGULAR/ directory.