### PR TITLE
.internals: updated release script to be more consistent

### DIFF
--- a/.internals/scripts/release.sh
+++ b/.internals/scripts/release.sh
@@ -190,14 +190,14 @@ while IFS="" read -r __line || [ -n "$__line" ]; do
 
         # build the file
         if [ "$__line" = "${PROJECT_PATH_AUTOMATA}" ]; then
-                ___dest="${___directory}/${PROJECT_SKU}-${PROJECT_VERSION}-core.tar.gz"
+                ___dest="${___directory}/${PROJECT_SKU}-core_${PROJECT_VERSION}.tar.gz"
                 FS_Remove_Silently "$___dest"
                 tar czvf "$___dest" \
                         -C "$PROJECT_PATH_ROOT" "$__line" \
                         -C "$PROJECT_PATH_ROOT" "CONFIG.toml" \
                         -C "$PROJECT_PATH_ROOT" ".gitignore"
         else
-                ___dest="${___directory}/${PROJECT_SKU}-${PROJECT_VERSION}-${__line}.tar.gz"
+                ___dest="${___directory}/${PROJECT_SKU}-${__line}_${PROJECT_VERSION}.tar.gz"
                 FS_Remove_Silently "$___dest"
                 tar czvf "$___dest" -C "$PROJECT_PATH_ROOT" "$__line"
         fi
@@ -225,7 +225,7 @@ find ".internals/docs/" -name '*.pdf' -print0 \
 
         ___file="${___file_src##*/}"
         ___file="$(FS_Extension_Remove "$___file" "*")"
-        ___dest="${___directory}/${PROJECT_SKU}-${PROJECT_VERSION}-user-guide_${___file##*_}.pdf"
+        ___dest="${___directory}/${PROJECT_SKU}-user-guide_${PROJECT_VERSION}_${___file##*_}.pdf"
         FS_Remove_Silently "$___dest"
         FS_Copy_File "$___file_src" "$___dest"
 done


### PR DESCRIPTION
The current naming convention is still inconsistent with out release script where the version should be leading with underscore and after the naming context; not mixed up. Hence, let's correct it.

This patch updates release script to be more consistent in .internals/ directory.