### PR TITLE
root: set AutomataCI's DOI to use Zenodo's general DOI instead

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -48,8 +48,8 @@ authors:
     affiliation: "Independent"
 identifiers:
   - type: doi
-    value: "10.5281/zenodo.10851740"
-    description: "Paper"
+    value: "10.5281/zenodo.10846862"
+    description: "General & Latest"
 keywords:
   - "continuous integration"
   - "native and locally available"

--- a/src/docs/CITATIONS.yml
+++ b/src/docs/CITATIONS.yml
@@ -63,8 +63,8 @@ authors:
     affiliation: "Independent"
 identifiers:
   - type: doi
-    value: "10.5281/zenodo.10851740"
-    description: "Paper"
+    value: "10.5281/zenodo.10846862"
+    description: "General & Latest"
 keywords:
   - "continuous integration"
   - "native and locally available"


### PR DESCRIPTION
The current headache with Zenodo's automatic DOI allocation is that the DOI issuing timing more of a chicken and egg problem. Luckily, there is a general DOI value for every linked GitHub repo. Hence, let's change it to use general DOI instead.

This patch set AutomataCI's DOI to use Zenodo's general DOI instead in root repository.