### PR TITLE
automataCI: ensure deb packager reacts to 'any' os and arch properly

### DIFF
--- a/automataCI/_package-deb_unix-any.sh
+++ b/automataCI/_package-deb_unix-any.sh
@@ -56,11 +56,11 @@ PACKAGE_Run_DEB() {
         I18N_Check_Availability "DEB"
         DEB_Is_Available "$_target_os" "$_target_arch"
         case $? in
-        2|3)
+        2)
                 I18N_Check_Incompatible_Skipped
                 return 0
                 ;;
-        0)
+        0|3)
                 # accepted
                 ;;
         *)

--- a/automataCI/_package-deb_windows-any.ps1
+++ b/automataCI/_package-deb_windows-any.ps1
@@ -46,10 +46,10 @@ function PACKAGE-Run-DEB {
 	$null = I18N-Check-Availability "DEB"
 	$___process = DEB-Is-Available "${_target_os}" "${_target_arch}"
 	switch ($___process) {
-	{ $_ -in 2, 3 } {
+	2 {
 		$null = I18N-Check-Incompatible-Skipped
 		return 0
-	} 0 {
+	} { $_ -in 0, 3 } {
 		# accepted
 	} Default {
 		$null = I18N-Check-Failed


### PR DESCRIPTION
The 'any' value for both target os and target arch are not properly handled for deb packager. This is a bug due to the misplaced response code handler. Hence, let's correct it.

This patch ensures deb packager reacts to 'any' os and arch properly in automataCI/ directory.