### PR TITLE
automataCI: fixed RPM responding to 'any' OS/ARCH type bug

### DIFF
--- a/automataCI/_package-rpm_unix-any.sh
+++ b/automataCI/_package-rpm_unix-any.sh
@@ -56,11 +56,11 @@ PACKAGE_Run_RPM() {
         I18N_Check_Availability "RPM"
         RPM_Is_Available "$_target_os" "$_target_arch"
         case $? in
-        2|3)
+        2)
                 I18N_Check_Incompatible_Skipped
                 return 0
                 ;;
-        0)
+        0|3)
                 # accepted
                 ;;
         *)

--- a/automataCI/_package-rpm_windows-any.ps1
+++ b/automataCI/_package-rpm_windows-any.ps1
@@ -47,10 +47,10 @@ function PACKAGE-Run-RPM {
 	$null = I18N-Check-Availability "RPM"
 	$___process = RPM-Is-Available "${_target_os}" "${_target_arch}"
 	switch ($___process) {
-	{ $_ -in 2, 3 } {
+	2 {
 		$null = I18N-Check-Incompatible-Skipped
 		return 0
-	} 0 {
+	} { $_ -in 0, 3 } {
 		# accepted
 	} Default {
 		$null = I18N-Check-Failed-Skipped

--- a/automataCI/services/compilers/rpm.ps1
+++ b/automataCI/services/compilers/rpm.ps1
@@ -464,7 +464,7 @@ function RPM-Is-Available {
 
 	# check compatible target os
 	switch ($___os) {
-	linux {
+	{ $_ -in linux, any } {
 		break
 	} default {
 		return 2

--- a/automataCI/services/compilers/rpm.sh
+++ b/automataCI/services/compilers/rpm.sh
@@ -475,7 +475,7 @@ RPM_Is_Available() {
 
         # check compatible target cpu architecture
         case "$___os" in
-        linux)
+        linux|any)
                 ;;
         *)
                 return 2


### PR DESCRIPTION
It appears the existing RPM packager does not respond to 'any' type for OS/ARCH values properly. Hence, let's amend it.

This patch fixes RPM responding to 'any' OS/ARCH type bug in automataCI/ directory.