### PR TITLE
root: fixed flatpak's unresponsive to 'any' value in OS/ARCH bug

### DIFF
--- a/automataCI/_package-flatpak_unix-any.sh
+++ b/automataCI/_package-flatpak_unix-any.sh
@@ -56,11 +56,11 @@ PACKAGE_Run_FLATPAK() {
         I18N_Check_Availability "FLATPAK"
         FLATPAK_Is_Available "$_target_os" "$_target_arch"
         case $? in
-        2|3)
+        2)
                 I18N_Check_Incompatible_Skipped
                 return 0
                 ;;
-        0)
+        0|3)
                 ;;
         *)
                 I18N_Check_Failed

--- a/automataCI/_package-flatpak_windows-any.ps1
+++ b/automataCI/_package-flatpak_windows-any.ps1
@@ -46,10 +46,10 @@ function PACKAGE-Run-FLATPAK {
 	$null = I18N-Check-Availability "FLATPAK"
 	$___process = FLATPAK-Is-Available "${_target_os}" "${_target_arch}"
 	switch ($___process) {
-	{ $_ -in 2, 3 } {
+	2 {
 		$null = I18N-Check-Incompatible-Skipped
 		return 0
-	} 0 {
+	} { $_ -in 0, 3 } {
 		break
 	} Default {
 		$null = I18N-Check-Failed

--- a/automataCI/services/compilers/flatpak.ps1
+++ b/automataCI/services/compilers/flatpak.ps1
@@ -132,7 +132,7 @@ function FLATPAK-Is-Available {
 
 	# check compatible target os
 	switch ($___os) {
-	linux {
+	{ $_ -in linux, any } {
 		# accepted
 	} Default {
 		return 2

--- a/automataCI/services/compilers/flatpak.sh
+++ b/automataCI/services/compilers/flatpak.sh
@@ -122,7 +122,7 @@ FLATPAK_Is_Available() {
 
         # check compatible target os
         case "$___os" in
-        linux)
+        linux|any)
                 # accepted
                 ;;
         *)

--- a/src/.ci/_package-flatpak_unix-any.sh
+++ b/src/.ci/_package-flatpak_unix-any.sh
@@ -63,7 +63,7 @@ PACKAGE_Assemble_FLATPAK_Content() {
                 return 10 # not applicable
         elif [ $(FS_Is_Target_A_PDF "$_target") -eq 0 ]; then
                 return 10 # not applicable
-        elif [ ! "$_target_os" = "linux" ]; then
+        elif [ ! "$_target_os" = "linux" ] && [ ! "$_target_os" = "any" ]; then
                 return 10 # not applicable
         fi
 

--- a/src/.ci/_package-flatpak_windows-any.ps1
+++ b/src/.ci/_package-flatpak_windows-any.ps1
@@ -63,7 +63,7 @@ function PACKAGE-Assemble-FLATPAK-Content {
 		return 10 # not applicable
 	} elseif ($(FS-Is-Target-A-PDF "${_target}") -eq 0) {
 		return 10 # not applicable
-	} elseif ($_target_os -ne "linux") {
+	} elseif (($_target_os -ne "linux") -and ($_target_os -ne "any")) {
 		return 10 # not applicable
 	}
 


### PR DESCRIPTION
It appears the flatpak packager is not responsive to 'any' value for OS/ARCH fields. Hence, we need to fix it.

This patch fixes flatpak's unresponsiveness to 'any' value in OS/ARCH field bug.