### PR TITLE
automataCI: fixed TARGET_OS and TARGET_ARCH extension pickup bug

### DIFF
--- a/automataCI/package_unix-any.sh
+++ b/automataCI/package_unix-any.sh
@@ -155,8 +155,10 @@ for i in "${PROJECT_PATH_ROOT}/${PROJECT_PATH_BUILD}"/*; do
         TARGET_FILENAME="${TARGET_FILENAME%.*}"
         TARGET_OS="${TARGET_FILENAME##*_}"
         TARGET_FILENAME="${TARGET_FILENAME%%_*}"
-        TARGET_ARCH="${TARGET_OS##*-}"
+        TARGET_ARCH="${TARGET_ARCH##*-}"
+        TARGET_ARCH="${TARGET_ARCH%%.*}"
         TARGET_OS="${TARGET_OS%%-*}"
+        TARGET_OS="${TARGET_OS%%.*}"
 
         if [ "$(STRINGS_Is_Empty "$TARGET_OS")" -eq 0 ] ||
                 [ "$(STRINGS_Is_Empty "$TARGET_ARCH")" -eq 0 ] ||

--- a/automataCI/package_windows-any.ps1
+++ b/automataCI/package_windows-any.ps1
@@ -170,8 +170,10 @@ foreach ($file in (Get-ChildItem -Path "${env:PROJECT_PATH_ROOT}\${env:PROJECT_P
 	$TARGET_FILENAME = $TARGET_FILENAME -replace "\..*$"
 	$TARGET_OS = $TARGET_FILENAME -replace ".*_"
 	$TARGET_FILENAME = $TARGET_FILENAME -replace "_.*"
-	$TARGET_ARCH = $TARGET_OS -replace ".*-"
+	$TARGET_ARCH = $TARGET_ARCH -replace ".*-"
+	$TARGET_ARCH = $TARGET_ARCH -replace "\..*$"
 	$TARGET_OS = $TARGET_OS -replace "-.*"
+	$TARGET_OS = $TARGET_OS -replace "\..*$"
 
 	if (($(STRINGS-Is-Empty "${TARGET_OS}") -eq 0) -or
 		($(STRINGS-Is-Empty "${TARGET_ARCH}") -eq 0) -or


### PR DESCRIPTION
It appears the TARGET_OS and TARGET_ARCH project variables are picking up compounded file extensions pattern. Hence, we need to clean them up. Let's do this.

This patch fixes TARGET_OS and TARGET_ARCH extension pickup bug in automataCI/ directory.