### PR TITLE
root: homebrew generates first character directory on release

### DIFF
--- a/automataCI/services/io/strings.ps1
+++ b/automataCI/services/io/strings.ps1
@@ -143,6 +143,69 @@ function STRINGS-To-Lowercase {
 
 
 
+function STRINGS-To-Titlecase {
+	param(
+		[string]$___content
+	)
+
+
+	# validate input
+	$___process = STRINGS-Is-Empty "${___content}"
+	if ($___process -eq 0) {
+		return ""
+	}
+
+
+	# execute
+	$___buffer = ""
+	$___resevoir = "${___content}"
+	$___trigger = $true
+	while ($___resevoir -ne "") {
+		## extract character
+		$___char = $___resevoir.Substring(0, 1)
+		if ($___char -eq "``") {
+			$___char = $___resevoir.Substring(0, 2)
+		}
+		$___resevoir = $___resevoir -replace "^${___char}", ""
+
+		## process character
+		if ($___trigger ) {
+			$___char = $___char.ToUpper()
+		} else {
+			$___char = $___char.ToLower()
+		}
+		$___buffer += $___char
+
+		## set next character action
+		switch ("${___char}") {
+		{ $_ -in " ", "`r", "`n" } {
+			$___trigger = $true
+		} default {
+			$___trigger = $false
+		}}
+	}
+
+
+	# report status
+	return $___buffer
+}
+
+
+
+
+function STRINGS-To-Uppercase {
+	param(
+		[string]$___content
+	)
+
+
+	# execute
+	return $___content.ToUpper()
+}
+
+
+
+
 function STRINGS-Trim-Whitespace-Left {
 	param(
 		[string]$___content
@@ -182,17 +245,4 @@ function STRINGS-Trim-Whitespace {
 
 	# report status
 	return $___content
-}
-
-
-
-
-function STRINGS-To-Uppercase {
-	param(
-		[string]$___content
-	)
-
-
-	# execute
-	return $___content.ToUpper()
 }

--- a/automataCI/services/io/strings.sh
+++ b/automataCI/services/io/strings.sh
@@ -141,6 +141,72 @@ STRINGS_To_Lowercase() {
 
 
 
+STRINGS_To_Titlecase() {
+        #___content="$1"
+
+
+        # validate input
+        if [ $(STRINGS_Is_Empty "$1") -eq 0 ]; then
+                printf -- ""
+                return 1
+        fi
+
+
+        # execute
+        ___buffer=""
+        ___resevoir="$1"
+        ___trigger=0
+        while [ -n "$___resevoir" ]; do
+                ## extract character
+                ___char="$(printf -- "%.1s" "$___resevoir")"
+                if [ "$___char" = '\' ]; then
+                        ___char="$(printf -- "%.2s" "$___resevoir")"
+                fi
+                ___resevoir="${___resevoir#*${___char}}"
+
+                ## process character
+                if [ $___trigger -eq 0 ]; then
+                        ___char="$(printf -- "%s" "$___char" | tr '[:lower:]' '[:upper:]')"
+                else
+                        ___char="$(printf -- "%s" "$___char" | tr '[:upper:]' '[:lower:]')"
+                fi
+                ___buffer="${___buffer}${___char}"
+
+                ## set next character action
+                case "$___char" in
+                " "|"\r"|"\n")
+                        ___trigger=0
+                        ;;
+                *)
+                        ___trigger=1
+                        ;;
+                esac
+        done
+
+
+        # report status
+        printf -- "%s" "$___buffer"
+        return 0
+}
+
+
+
+
+STRINGS_To_Uppercase() {
+        #___content="$1"
+
+
+        # execute
+        printf -- "%b" "$1" | tr '[:lower:]' '[:upper:]'
+
+
+        # report status
+        return 0
+}
+
+
+
+
 STRINGS_Trim_Whitespace_Left() {
         #___content="$1"
 
@@ -180,21 +246,6 @@ STRINGS_Trim_Whitespace() {
         ___content="$(STRINGS_Trim_Whitespace_Right "$___content")"
         printf -- "%b" "$___content"
         unset ___content
-
-
-        # report status
-        return 0
-}
-
-
-
-
-STRINGS_To_Uppercase() {
-        #___content="$1"
-
-
-        # execute
-        printf -- "%b" "$1" | tr '[:lower:]' '[:upper:]'
 
 
         # report status

--- a/srcC/.ci/_package-homebrew_unix-any.sh
+++ b/srcC/.ci/_package-homebrew_unix-any.sh
@@ -21,6 +21,7 @@ if [ "$PROJECT_PATH_ROOT" = "" ]; then
 fi
 
 . "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/strings.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
 
 
@@ -106,11 +107,11 @@ PACKAGE_Assemble_HOMEBREW_Content() {
         ___dest="${_directory}/formula.rb"
         I18N_Create "$___dest"
         FS_Write_File "$___dest" "\
-class ${PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS_To_Titlecase "$PROJECT_SKU") < Formula
   desc \"${PROJECT_PITCH}\"
   homepage \"${PROJECT_CONTACT_WEBSITE}\"
   license \"${PROJECT_LICENSE}\"
-  url \"${PROJECT_HOMEBREW_SOURCE_URL}/${PROJECT_VERSION}/{{ TARGET_PACKAGE }}\"
+  url \"${PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}\"
   sha256 \"{{ TARGET_SHASUM }}\"
 
   on_linux do
@@ -126,7 +127,8 @@ class ${PROJECT_SKU_TITLECASE} < Formula
     system \"./automataCI/ci.sh.ps1 prepare\"
     system \"./automataCI/ci.sh.ps1 materialize\"
     chmod 0755, \"bin/${PROJECT_SKU}\"
-    bin.install \"bin/${PROJECT_SKU}\"
+    libexec.install \"bin/${PROJECT_SKU}\"
+    bin.install_symlink libexec/\"${PROJECT_SKU}\" => \"${PROJECT_SKU}\"
   end
 
   test do

--- a/srcC/.ci/_package-homebrew_windows-any.ps1
+++ b/srcC/.ci/_package-homebrew_windows-any.ps1
@@ -20,6 +20,7 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 }
 
 . "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\translations.ps1"
 
 
@@ -107,11 +108,11 @@ function PACKAGE-Assemble-HOMEBREW-Content {
 	$___dest = "${_directory}\formula.rb"
 	$null = I18N-Create "${___dest}"
 	$___process = FS-Write-File "${___dest}" @"
-class ${env:PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS-To-Titlecase "${env:PROJECT_SKU}") < Formula
   desc "${env:PROJECT_PITCH}"
   homepage "${env:PROJECT_CONTACT_WEBSITE}"
   license "${env:PROJECT_LICENSE}"
-  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/${env:PROJECT_VERSION}/{{ TARGET_PACKAGE }}"
+  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}"
   sha256 "{{ TARGET_SHASUM }}"
 
   on_linux do
@@ -127,7 +128,8 @@ class ${env:PROJECT_SKU_TITLECASE} < Formula
     system "./automataCI/ci.sh.ps1 prepare"
     system "./automataCI/ci.sh.ps1 materialize"
     chmod 0755, "bin/${env:PROJECT_SKU}"
-    bin.install "bin/${env:PROJECT_SKU}"
+    libexec.install "bin/${env:PROJECT_SKU}"
+    bin.install_symlink libexec/"${env:PROJECT_SKU}" => "${env:PROJECT_SKU}"
   end
 
   test do

--- a/srcGO/.ci/_package-homebrew_unix-any.sh
+++ b/srcGO/.ci/_package-homebrew_unix-any.sh
@@ -106,13 +106,12 @@ PACKAGE_Assemble_HOMEBREW_Content() {
         ___dest="${_directory}/formula.rb"
         I18N_Create "$___dest"
         FS_Write_File "$___dest" "\
-class ${PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS_To_Titlecase "$PROJECT_SKU") < Formula
   desc \"${PROJECT_PITCH}\"
   homepage \"${PROJECT_CONTACT_WEBSITE}\"
   license \"${PROJECT_LICENSE}\"
-  url \"${PROJECT_HOMEBREW_SOURCE_URL}/${PROJECT_VERSION}/{{ TARGET_PACKAGE }}\"
+  url \"${PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}\"
   sha256 \"{{ TARGET_SHASUM }}\"
-
 
   depends_on \"go\" => [:build, :test]
 
@@ -121,7 +120,8 @@ class ${PROJECT_SKU_TITLECASE} < Formula
     system \"./automataCI/ci.sh.ps1 prepare\"
     system \"./automataCI/ci.sh.ps1 materialize\"
     chmod 0755, \"bin/${PROJECT_SKU}\"
-    bin.install \"bin/${PROJECT_SKU}\"
+    libexec.install \"bin/${PROJECT_SKU}\"
+    bin.install_symlink libexec/\"${PROJECT_SKU}\" => \"${PROJECT_SKU}\"
   end
 
   test do

--- a/srcGO/.ci/_package-homebrew_windows-any.ps1
+++ b/srcGO/.ci/_package-homebrew_windows-any.ps1
@@ -20,6 +20,7 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 }
 
 . "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\translations.ps1"
 
 
@@ -107,20 +108,22 @@ function PACKAGE-Assemble-HOMEBREW-Content {
 	$___dest = "${_directory}\formula.rb"
 	$null = I18N-Create "${___dest}"
 	$___process = FS-Write-File "${___dest}" @"
-class ${env:PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS-To-Titlecase "${env:PROJECT_SKU}") < Formula
   desc "${env:PROJECT_PITCH}"
   homepage "${env:PROJECT_CONTACT_WEBSITE}"
   license "${env:PROJECT_LICENSE}"
-  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/${env:PROJECT_VERSION}/{{ TARGET_PACKAGE }}"
+  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}"
   sha256 "{{ TARGET_SHASUM }}"
 
+  depends_on \"go\" => [:build, :test]
 
   def install
     system "./automataCI/ci.sh.ps1 setup"
     system "./automataCI/ci.sh.ps1 prepare"
     system "./automataCI/ci.sh.ps1 materialize"
     chmod 0755, "bin/${env:PROJECT_SKU}"
-    bin.install "bin/${env:PROJECT_SKU}"
+    libexec.install "bin/${env:PROJECT_SKU}"
+    bin.install_symlink libexec/"${env:PROJECT_SKU}" => "${env:PROJECT_SKU}"
   end
 
   test do

--- a/srcNIM/.ci/_package-homebrew_unix-any.sh
+++ b/srcNIM/.ci/_package-homebrew_unix-any.sh
@@ -21,6 +21,7 @@ if [ "$PROJECT_PATH_ROOT" = "" ]; then
 fi
 
 . "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/strings.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
 
 
@@ -106,11 +107,11 @@ PACKAGE_Assemble_HOMEBREW_Content() {
         ___dest="${_directory}/formula.rb"
         I18N_Create "$___dest"
         FS_Write_File "$___dest" "\
-class ${PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS_To_Titlecase "$PROJECT_SKU") < Formula
   desc \"${PROJECT_PITCH}\"
   homepage \"${PROJECT_CONTACT_WEBSITE}\"
   license \"${PROJECT_LICENSE}\"
-  url \"${PROJECT_HOMEBREW_SOURCE_URL}/${PROJECT_VERSION}/{{ TARGET_PACKAGE }}\"
+  url \"${PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}\"
   sha256 \"{{ TARGET_SHASUM }}\"
 
   depends_on \"nim\" => [:build, :test]
@@ -128,7 +129,8 @@ class ${PROJECT_SKU_TITLECASE} < Formula
     system \"./automataCI/ci.sh.ps1 prepare\"
     system \"./automataCI/ci.sh.ps1 materialize\"
     chmod 0755, \"bin/${PROJECT_SKU}\"
-    bin.install \"bin/${PROJECT_SKU}\"
+    libexec.install \"bin/${PROJECT_SKU}\"
+    bin.install_symlink libexec/\"${PROJECT_SKU}\" => \"${PROJECT_SKU}\"
   end
 
   test do

--- a/srcNIM/.ci/_package-homebrew_windows-any.ps1
+++ b/srcNIM/.ci/_package-homebrew_windows-any.ps1
@@ -20,6 +20,7 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 }
 
 . "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\translations.ps1"
 
 
@@ -107,11 +108,11 @@ function PACKAGE-Assemble-HOMEBREW-Content {
 	$___dest = "${_directory}\formula.rb"
 	$null = I18N-Create "${___dest}"
 	$___process = FS-Write-File "${___dest}" @"
-class ${env:PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS-To-Titlecase "${env:PROJECT_SKU}") < Formula
   desc "${env:PROJECT_PITCH}"
   homepage "${env:PROJECT_CONTACT_WEBSITE}"
   license "${env:PROJECT_LICENSE}"
-  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/${env:PROJECT_VERSION}/{{ TARGET_PACKAGE }}"
+  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}"
   sha256 "{{ TARGET_SHASUM }}"
 
   depends_on \"nim\" => [:build, :test]
@@ -129,7 +130,8 @@ class ${env:PROJECT_SKU_TITLECASE} < Formula
     system "./automataCI/ci.sh.ps1 prepare"
     system "./automataCI/ci.sh.ps1 materialize"
     chmod 0755, "bin/${env:PROJECT_SKU}"
-    bin.install "bin/${env:PROJECT_SKU}"
+    libexec.install "bin/${env:PROJECT_SKU}"
+    bin.install_symlink libexec/"${env:PROJECT_SKU}" => "${env:PROJECT_SKU}"
   end
 
   test do

--- a/srcPYTHON/.ci/_package-homebrew_unix-any.sh
+++ b/srcPYTHON/.ci/_package-homebrew_unix-any.sh
@@ -21,6 +21,7 @@ if [ "$PROJECT_PATH_ROOT" = "" ]; then
 fi
 
 . "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/strings.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
 . "${LIBS_AUTOMATACI}/services/compilers/python.sh"
 
@@ -108,13 +109,12 @@ PACKAGE_Assemble_HOMEBREW_Content() {
         ___dest="${_directory}/formula.rb"
         I18N_Create "$___dest"
         FS_Write_File "$___dest" "\
-class ${PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS_To_Titlecase "$PROJECT_SKU") < Formula
   desc \"${PROJECT_PITCH}\"
   homepage \"${PROJECT_CONTACT_WEBSITE}\"
   license \"${PROJECT_LICENSE}\"
-  url \"${PROJECT_HOMEBREW_SOURCE_URL}/${PROJECT_VERSION}/{{ TARGET_PACKAGE }}\"
+  url \"${PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}\"
   sha256 \"{{ TARGET_SHASUM }}\"
-
 
   depends_on \"python\" => [:build, :test]
 
@@ -123,7 +123,8 @@ class ${PROJECT_SKU_TITLECASE} < Formula
     system \"./automataCI/ci.sh.ps1 prepare\"
     system \"./automataCI/ci.sh.ps1 materialize\"
     chmod 0755, \"bin/${PROJECT_SKU}\"
-    bin.install \"bin/${PROJECT_SKU}\"
+    libexec.install \"bin/${PROJECT_SKU}\"
+    bin.install_symlink libexec/\"${PROJECT_SKU}\" => \"${PROJECT_SKU}\"
   end
 
   test do

--- a/srcPYTHON/.ci/_package-homebrew_windows-any.ps1
+++ b/srcPYTHON/.ci/_package-homebrew_windows-any.ps1
@@ -20,6 +20,7 @@ if (-not (Test-Path -Path $env:PROJECT_PATH_ROOT)) {
 }
 
 . "${env:LIBS_AUTOMATACI}\services\io\fs.ps1"
+. "${env:LIBS_AUTOMATACI}\services\io\strings.ps1"
 . "${env:LIBS_AUTOMATACI}\services\i18n\translations.ps1"
 . "${env:LIBS_AUTOMATACI}\services\compilers\python.ps1"
 
@@ -109,11 +110,11 @@ function PACKAGE-Assemble-HOMEBREW-Content {
 	$___dest = "${_directory}\formula.rb"
 	$null = I18N-Create "${___dest}"
 	$___process = FS-Write-File "${___dest}" @"
-class ${env:PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS-To-Titlecase "${env:PROJECT_SKU}") < Formula
   desc "${env:PROJECT_PITCH}"
   homepage "${env:PROJECT_CONTACT_WEBSITE}"
   license "${env:PROJECT_LICENSE}"
-  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/${env:PROJECT_VERSION}/{{ TARGET_PACKAGE }}"
+  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}"
   sha256 "{{ TARGET_SHASUM }}"
 
   depends_on "python" => [:build, :test]
@@ -123,7 +124,8 @@ class ${env:PROJECT_SKU_TITLECASE} < Formula
     system "./automataCI/ci.sh.ps1 prepare"
     system "./automataCI/ci.sh.ps1 materialize"
     chmod 0755, "bin/${env:PROJECT_SKU}"
-    bin.install "bin/${env:PROJECT_SKU}"
+    libexec.install "bin/${env:PROJECT_SKU}"
+    bin.install_symlink libexec/"${env:PROJECT_SKU}" => "${env:PROJECT_SKU}"
   end
 
   test do

--- a/srcRUST/.ci/_package-homebrew_unix-any.sh
+++ b/srcRUST/.ci/_package-homebrew_unix-any.sh
@@ -21,6 +21,7 @@ if [ "$PROJECT_PATH_ROOT" = "" ]; then
 fi
 
 . "${LIBS_AUTOMATACI}/services/io/fs.sh"
+. "${LIBS_AUTOMATACI}/services/io/strings.sh"
 . "${LIBS_AUTOMATACI}/services/i18n/translations.sh"
 . "${LIBS_AUTOMATACI}/services/compilers/rust.sh"
 
@@ -128,11 +129,11 @@ PACKAGE_Assemble_HOMEBREW_Content() {
         ___dest="${_directory}/formula.rb"
         I18N_Create "$___dest"
         FS_Write_File "$___dest" "\
-class ${PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS_To_Titlecase "$PROJECT_SKU") < Formula
   desc \"${PROJECT_PITCH}\"
   homepage \"${PROJECT_CONTACT_WEBSITE}\"
   license \"${PROJECT_LICENSE}\"
-  url \"${PROJECT_HOMEBREW_SOURCE_URL}/${PROJECT_VERSION}/{{ TARGET_PACKAGE }}\"
+  url \"${PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}\"
   sha256 \"{{ TARGET_SHASUM }}\"
 
 
@@ -141,7 +142,8 @@ class ${PROJECT_SKU_TITLECASE} < Formula
     system \"./automataCI/ci.sh.ps1 prepare\"
     system \"./automataCI/ci.sh.ps1 materialize\"
     chmod 0755, \"bin/${PROJECT_SKU}\"
-    bin.install \"bin/${PROJECT_SKU}\"
+    libexec.install \"bin/${PROJECT_SKU}\"
+    bin.install_symlink libexec/\"${PROJECT_SKU}\" => \"${PROJECT_SKU}\"
   end
 
   test do

--- a/srcRUST/.ci/_package-homebrew_windows-any.ps1
+++ b/srcRUST/.ci/_package-homebrew_windows-any.ps1
@@ -129,20 +129,20 @@ function PACKAGE-Assemble-HOMEBREW-Content {
 	$___dest = "${_directory}\formula.rb"
 	$null = I18N-Create "${___dest}"
 	$___process = FS-Write-File "${___dest}" @"
-class ${env:PROJECT_SKU_TITLECASE} < Formula
+class $(STRINGS-To-Titlecase "${env:PROJECT_SKU}") < Formula
   desc "${env:PROJECT_PITCH}"
   homepage "${env:PROJECT_CONTACT_WEBSITE}"
   license "${env:PROJECT_LICENSE}"
-  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/${env:PROJECT_VERSION}/{{ TARGET_PACKAGE }}"
+  url "${env:PROJECT_HOMEBREW_SOURCE_URL}/{{ TARGET_PACKAGE }}"
   sha256 "{{ TARGET_SHASUM }}"
-
 
   def install
     system "./automataCI/ci.sh.ps1 setup"
     system "./automataCI/ci.sh.ps1 prepare"
     system "./automataCI/ci.sh.ps1 materialize"
     chmod 0755, "bin/${env:PROJECT_SKU}"
-    bin.install "bin/${env:PROJECT_SKU}"
+    libexec.install "bin/${env:PROJECT_SKU}"
+    bin.install_symlink libexec/"${env:PROJECT_SKU}" => "${env:PROJECT_SKU}"
   end
 
   test do


### PR DESCRIPTION
To make sure the Homebrew is scalable, it's better to utilize its first character directory feature upon release. Hence, let's upgrade it.

This patch upgrades homebrew to generate first character directory on release in root repository.